### PR TITLE
feat: add ERD model and confidence foundation

### DIFF
--- a/docs/agents/06-contradictions-and-cleanup.md
+++ b/docs/agents/06-contradictions-and-cleanup.md
@@ -5,6 +5,7 @@
 - [Cleanup policy](#cleanup-policy)
 
 ## Resolved contradictions
+
 - Home-level AGENTS text references `/Users/jamiecraik/dev/configs/codex` as a repo-specific preflight path.
 - For this repository scope, the nearest-repo guidance applies and uses `/Users/jamiecraik/dev/diagram-cli` as the working root.
 - Node runtime expectations vary by source. Package metadata requires `node >=18`, while workflows currently include Node 20, 24, and 25 lanes.

--- a/docs/agents/06-contradictions-and-cleanup.md
+++ b/docs/agents/06-contradictions-and-cleanup.md
@@ -5,7 +5,7 @@
 - [Cleanup policy](#cleanup-policy)
 
 ## Resolved contradictions
-- Home-level AGENTS text references `/Users/jamiecraik/dev/config/codex` as a repo-specific preflight path.
+- Home-level AGENTS text references `/Users/jamiecraik/dev/configs/codex` as a repo-specific preflight path.
 - For this repository scope, the nearest-repo guidance applies and uses `/Users/jamiecraik/dev/diagram-cli` as the working root.
 - Node runtime expectations vary by source. Package metadata requires `node >=18`, while workflows currently include Node 20, 24, and 25 lanes.
 

--- a/scripts/check-environment.sh
+++ b/scripts/check-environment.sh
@@ -13,7 +13,7 @@ CONTRACT_PATH="$REPO_ROOT/harness.contract.json"
 	MAKEFILE_PATH="$REPO_ROOT/Makefile"
 	PREK_CONFIG_PATH="$REPO_ROOT/prek.toml"
 	PACKAGE_JSON_PATH="$REPO_ROOT/package.json"
-	TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-$HOME/dev/config/codex/instructions/tooling.md}"
+	TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-$HOME/dev/configs/codex/instructions/tooling.md}"
 
 if [[ ! -f "$CONTRACT_PATH" ]]; then
 	echo "Error: missing contract file at $CONTRACT_PATH"

--- a/scripts/check-environment.sh
+++ b/scripts/check-environment.sh
@@ -7,13 +7,23 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 CONTRACT_PATH="$REPO_ROOT/harness.contract.json"
-	ATTESTATION_PATH="$REPO_ROOT/artifacts/policy/environment-attestation.json"
-	MISE_PATH="$REPO_ROOT/.mise.toml"
-	CODEX_ENVIRONMENT_PATH="$REPO_ROOT/.codex/environments/environment.toml"
-	MAKEFILE_PATH="$REPO_ROOT/Makefile"
-	PREK_CONFIG_PATH="$REPO_ROOT/prek.toml"
-	PACKAGE_JSON_PATH="$REPO_ROOT/package.json"
-	TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-$HOME/dev/configs/codex/instructions/tooling.md}"
+ATTESTATION_PATH="$REPO_ROOT/artifacts/policy/environment-attestation.json"
+MISE_PATH="$REPO_ROOT/.mise.toml"
+CODEX_ENVIRONMENT_PATH="$REPO_ROOT/.codex/environments/environment.toml"
+MAKEFILE_PATH="$REPO_ROOT/Makefile"
+PREK_CONFIG_PATH="$REPO_ROOT/prek.toml"
+PACKAGE_JSON_PATH="$REPO_ROOT/package.json"
+TOOLING_DOC_PRIMARY_PATH="$HOME/dev/configs/codex/instructions/tooling.md"
+TOOLING_DOC_LEGACY_PATH="$HOME/dev/config/codex/instructions/tooling.md"
+TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-}"
+
+if [[ -z "$TOOLING_DOC_PATH" ]]; then
+	if [[ -f "$TOOLING_DOC_PRIMARY_PATH" ]]; then
+		TOOLING_DOC_PATH="$TOOLING_DOC_PRIMARY_PATH"
+	else
+		TOOLING_DOC_PATH="$TOOLING_DOC_LEGACY_PATH"
+	fi
+fi
 
 if [[ ! -f "$CONTRACT_PATH" ]]; then
 	echo "Error: missing contract file at $CONTRACT_PATH"

--- a/scripts/check-environment.sh
+++ b/scripts/check-environment.sh
@@ -7,21 +7,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 CONTRACT_PATH="$REPO_ROOT/harness.contract.json"
-ATTESTATION_PATH="$REPO_ROOT/artifacts/policy/environment-attestation.json"
-MISE_PATH="$REPO_ROOT/.mise.toml"
-CODEX_ENVIRONMENT_PATH="$REPO_ROOT/.codex/environments/environment.toml"
-MAKEFILE_PATH="$REPO_ROOT/Makefile"
-PREK_CONFIG_PATH="$REPO_ROOT/prek.toml"
-PACKAGE_JSON_PATH="$REPO_ROOT/package.json"
-TOOLING_DOC_PRIMARY_PATH="$HOME/dev/configs/codex/instructions/tooling.md"
-TOOLING_DOC_LEGACY_PATH="$HOME/dev/config/codex/instructions/tooling.md"
-TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-}"
+	ATTESTATION_PATH="$REPO_ROOT/artifacts/policy/environment-attestation.json"
+	MISE_PATH="$REPO_ROOT/.mise.toml"
+	CODEX_ENVIRONMENT_PATH="$REPO_ROOT/.codex/environments/environment.toml"
+	MAKEFILE_PATH="$REPO_ROOT/Makefile"
+	PREK_CONFIG_PATH="$REPO_ROOT/prek.toml"
+	PACKAGE_JSON_PATH="$REPO_ROOT/package.json"
+	TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-}"
 
 if [[ -z "$TOOLING_DOC_PATH" ]]; then
-	if [[ -f "$TOOLING_DOC_PRIMARY_PATH" ]]; then
-		TOOLING_DOC_PATH="$TOOLING_DOC_PRIMARY_PATH"
+	if [[ -f "$HOME/dev/configs/codex/instructions/tooling.md" ]]; then
+		TOOLING_DOC_PATH="$HOME/dev/configs/codex/instructions/tooling.md"
 	else
-		TOOLING_DOC_PATH="$TOOLING_DOC_LEGACY_PATH"
+		TOOLING_DOC_PATH="$HOME/dev/config/codex/instructions/tooling.md"
 	fi
 fi
 

--- a/src/schema/erd-confidence.js
+++ b/src/schema/erd-confidence.js
@@ -1,0 +1,56 @@
+function roundTo(value, precision = 3) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function evaluateErdConfidence(model) {
+  const entities = Array.isArray(model?.entities) ? model.entities : [];
+  const relationships = Array.isArray(model?.relationships) ? model.relationships : [];
+
+  const entityCount = entities.length;
+  const explicitEntityCount = entities.filter((entity) => entity.source === 'explicit').length;
+  const relationshipCount = relationships.length;
+  const inferredRelationshipCount = relationships.filter(
+    (relationship) => relationship.provenance === 'inferred'
+  ).length;
+  const explicitRelationshipCount = relationships.filter(
+    (relationship) => relationship.provenance === 'explicit'
+  ).length;
+
+  const inferenceShare = relationshipCount > 0
+    ? inferredRelationshipCount / relationshipCount
+    : 0;
+
+  let outcome = 'publishable';
+  if (
+    entityCount === 0
+    || explicitEntityCount === 0
+    || (relationshipCount > 0 && inferenceShare > 0.8)
+  ) {
+    outcome = 'fail_confidence';
+  } else if (
+    relationshipCount > 0
+    && inferenceShare > 0.5
+    && inferenceShare <= 0.8
+  ) {
+    outcome = 'publishable_with_marker';
+  }
+
+  return {
+    outcome,
+    shouldFail: outcome === 'fail_confidence',
+    markerRequired: outcome === 'publishable_with_marker',
+    counts: {
+      entityCount,
+      explicitEntityCount,
+      relationshipCount,
+      explicitRelationshipCount,
+      inferredRelationshipCount,
+      inferenceShare: roundTo(inferenceShare, 4),
+    },
+  };
+}
+
+module.exports = {
+  evaluateErdConfidence,
+};

--- a/src/schema/erd-model.js
+++ b/src/schema/erd-model.js
@@ -1,0 +1,176 @@
+function sanitizeToken(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[`"'\\]/g, '')
+    .replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+function canonicalEntityName(value) {
+  const token = sanitizeToken(value);
+  return token ? token.toUpperCase() : '';
+}
+
+function canonicalAttributeName(value) {
+  return sanitizeToken(value);
+}
+
+function canonicalType(value) {
+  const token = sanitizeToken(value);
+  return token || 'unknown';
+}
+
+function toKeyFlags(flags) {
+  const order = ['PK', 'FK', 'UK'];
+  const seen = new Set((Array.isArray(flags) ? flags : []).map((flag) => String(flag).toUpperCase()));
+  return order.filter((flag) => seen.has(flag));
+}
+
+function mergeAttributes(existingAttributes, incomingAttributes) {
+  const byName = new Map();
+
+  for (const attribute of [...existingAttributes, ...incomingAttributes]) {
+    const name = canonicalAttributeName(attribute?.name);
+    if (!name) continue;
+    const prev = byName.get(name);
+    const next = {
+      name,
+      type: canonicalType(attribute?.type),
+      nullable: Boolean(attribute?.nullable),
+      keyFlags: toKeyFlags(attribute?.keyFlags),
+    };
+
+    if (!prev) {
+      byName.set(name, next);
+      continue;
+    }
+
+    const mergedFlags = toKeyFlags([...(prev.keyFlags || []), ...(next.keyFlags || [])]);
+    byName.set(name, {
+      name,
+      type: prev.type !== 'unknown' ? prev.type : next.type,
+      nullable: prev.nullable || next.nullable,
+      keyFlags: mergedFlags,
+    });
+  }
+
+  const keyPriority = ['PK', 'FK', 'UK'];
+  const score = (attribute) => {
+    if ((attribute.keyFlags || []).length === 0) return keyPriority.length;
+    const positions = attribute.keyFlags
+      .map((flag) => keyPriority.indexOf(flag))
+      .filter((index) => index >= 0);
+    return positions.length > 0 ? Math.min(...positions) : keyPriority.length;
+  };
+
+  return [...byName.values()].sort((a, b) => {
+    const scoreDiff = score(a) - score(b);
+    if (scoreDiff !== 0) return scoreDiff;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function normalizeErdModel(input) {
+  const entitiesInput = Array.isArray(input?.entities) ? input.entities : [];
+  const relationshipsInput = Array.isArray(input?.relationships) ? input.relationships : [];
+  const diagnostics = Array.isArray(input?.diagnostics) ? input.diagnostics : [];
+  const sourceFiles = Array.isArray(input?.sourceFiles) ? input.sourceFiles : [];
+  const sourcePrecedence = Array.isArray(input?.sourcePrecedence) ? input.sourcePrecedence : [];
+
+  const entitiesByName = new Map();
+  for (const entity of entitiesInput) {
+    const name = canonicalEntityName(entity?.name);
+    if (!name) continue;
+    const source = entity?.source === 'inferred' ? 'inferred' : 'explicit';
+    const existing = entitiesByName.get(name);
+    const attributes = mergeAttributes(existing?.attributes || [], entity?.attributes || []);
+    const merged = {
+      name,
+      source: existing?.source === 'explicit' || source === 'explicit' ? 'explicit' : 'inferred',
+      attributes,
+    };
+    entitiesByName.set(name, merged);
+  }
+
+  const entities = [...entitiesByName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const entitySet = new Set(entities.map((entity) => entity.name));
+  const relationshipMap = new Map();
+
+  for (const relationship of relationshipsInput) {
+    const fromEntity = canonicalEntityName(relationship?.fromEntity);
+    const toEntity = canonicalEntityName(relationship?.toEntity);
+    if (!fromEntity || !toEntity) continue;
+    if (!entitySet.has(fromEntity) || !entitySet.has(toEntity)) continue;
+
+    const provenance = relationship?.provenance === 'inferred' ? 'inferred' : 'explicit';
+    const cardinality = String(relationship?.cardinality || '||--o{');
+    const relationshipKey = `${fromEntity}|${toEntity}|${cardinality}`;
+    const existing = relationshipMap.get(relationshipKey);
+    if (!existing || existing.provenance === 'inferred') {
+      relationshipMap.set(relationshipKey, {
+        fromEntity,
+        toEntity,
+        cardinality,
+        provenance,
+      });
+    }
+  }
+
+  const relationships = [...relationshipMap.values()].sort((a, b) => {
+    if (a.fromEntity !== b.fromEntity) return a.fromEntity.localeCompare(b.fromEntity);
+    if (a.toEntity !== b.toEntity) return a.toEntity.localeCompare(b.toEntity);
+    if (a.provenance !== b.provenance) return a.provenance.localeCompare(b.provenance);
+    return a.cardinality.localeCompare(b.cardinality);
+  });
+
+  return {
+    entities,
+    relationships,
+    diagnostics,
+    sourceFiles: [...new Set(sourceFiles)].sort(),
+    sourcePrecedence: [...new Set(sourcePrecedence)],
+  };
+}
+
+function renderErdMermaid(model, options = {}) {
+  const entities = Array.isArray(model?.entities) ? model.entities : [];
+  const relationships = Array.isArray(model?.relationships) ? model.relationships : [];
+  const lines = ['erDiagram'];
+
+  if (options.lowConfidenceMarker) {
+    const percent = typeof options.inferenceShare === 'number'
+      ? Math.round(options.inferenceShare * 100)
+      : null;
+    const marker = percent === null
+      ? 'low-confidence: inferred relationships are above preferred threshold'
+      : `low-confidence: inferred relationships are ${percent}% of all relationships`;
+    lines.push(`  %% ${marker}`);
+  }
+
+  for (const entity of entities) {
+    lines.push(`  ${entity.name} {`);
+    for (const attribute of entity.attributes || []) {
+      const flags = (attribute.keyFlags || []).join(' ');
+      const suffix = flags ? ` ${flags}` : '';
+      lines.push(`    ${canonicalType(attribute.type)} ${canonicalAttributeName(attribute.name)}${suffix}`);
+    }
+    lines.push('  }');
+  }
+
+  if (relationships.length > 0) {
+    lines.push('');
+  }
+
+  for (const relationship of relationships) {
+    lines.push(
+      `  ${relationship.fromEntity} ${relationship.cardinality} ${relationship.toEntity} : ${relationship.provenance}`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  canonicalEntityName,
+  normalizeErdModel,
+  renderErdMermaid,
+};

--- a/test/erd-confidence.test.js
+++ b/test/erd-confidence.test.js
@@ -37,6 +37,64 @@ describe('erd confidence policy', () => {
     expect(evaluated.counts.inferenceShare).to.equal(0.6667);
   });
 
+  it('keeps publishable at inferenceShare boundary 0.5', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('publishable');
+    expect(evaluated.markerRequired).to.equal(false);
+    expect(evaluated.counts.inferenceShare).to.equal(0.5);
+  });
+
+  it('marks publishable_with_marker at inferenceShare boundary 0.8', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
+        { fromEntity: 'USER', toEntity: 'USER', provenance: 'inferred' },
+        { fromEntity: 'SESSION', toEntity: 'SESSION', provenance: 'inferred' },
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('publishable_with_marker');
+    expect(evaluated.markerRequired).to.equal(true);
+    expect(evaluated.counts.inferenceShare).to.equal(0.8);
+  });
+
+  it('fails confidence when inferenceShare is greater than 0.8', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
+        { fromEntity: 'USER', toEntity: 'USER', provenance: 'inferred' },
+        { fromEntity: 'SESSION', toEntity: 'SESSION', provenance: 'inferred' },
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' },
+        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('fail_confidence');
+    expect(evaluated.markerRequired).to.equal(false);
+    expect(evaluated.counts.inferenceShare).to.equal(0.8333);
+  });
+
   it('classifies fail_confidence when no explicit entities are available', () => {
     const evaluated = evaluateErdConfidence({
       entities: [],
@@ -45,5 +103,14 @@ describe('erd confidence policy', () => {
 
     expect(evaluated.outcome).to.equal('fail_confidence');
     expect(evaluated.shouldFail).to.equal(true);
+    expect(evaluated.markerRequired).to.equal(false);
+    expect(evaluated.counts).to.deep.equal({
+      entityCount: 0,
+      explicitEntityCount: 0,
+      relationshipCount: 0,
+      explicitRelationshipCount: 0,
+      inferredRelationshipCount: 0,
+      inferenceShare: 0,
+    });
   });
 });

--- a/test/erd-confidence.test.js
+++ b/test/erd-confidence.test.js
@@ -2,10 +2,7 @@ const { expect } = require('chai');
 const { evaluateErdConfidence } = require('../src/schema/erd-confidence');
 
 function evaluateShare({ inferred, explicit }) {
-  const relationships = [
-    ...Array.from({ length: explicit }, () => ({ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' })),
-    ...Array.from({ length: inferred }, () => ({ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' })),
-  ];
+  const relationships = [...Array.from({ length: explicit }, () => ({ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' })), ...Array.from({ length: inferred }, () => ({ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' }))];
   return evaluateErdConfidence({ entities: [{ name: 'USER', source: 'explicit' }], relationships });
 }
 
@@ -21,11 +18,7 @@ describe('erd confidence policy', () => {
   });
 
   it('handles boundary thresholds at 0.5, 0.8, and >0.8 inference share', () => {
-    const cases = [
-      { inferred: 1, explicit: 1, outcome: 'publishable', markerRequired: false, inferenceShare: 0.5 },
-      { inferred: 4, explicit: 1, outcome: 'publishable_with_marker', markerRequired: true, inferenceShare: 0.8 },
-      { inferred: 5, explicit: 1, outcome: 'fail_confidence', markerRequired: false, inferenceShare: 0.8333 },
-    ];
+    const cases = [{ inferred: 1, explicit: 1, outcome: 'publishable', markerRequired: false, inferenceShare: 0.5 }, { inferred: 4, explicit: 1, outcome: 'publishable_with_marker', markerRequired: true, inferenceShare: 0.8 }, { inferred: 5, explicit: 1, outcome: 'fail_confidence', markerRequired: false, inferenceShare: 0.8333 }];
     for (const expected of cases) {
       const evaluated = evaluateShare(expected);
       expect(evaluated.outcome).to.equal(expected.outcome);
@@ -33,7 +26,6 @@ describe('erd confidence policy', () => {
       expect(evaluated.counts.inferenceShare).to.equal(expected.inferenceShare);
     }
   });
-
   it('classifies publishable_with_marker when inferred relationships dominate but stay <= 0.8', () => {
     const evaluated = evaluateErdConfidence({
       entities: [{ name: 'USER', source: 'explicit' }, { name: 'SESSION', source: 'explicit' }, { name: 'COMMENT', source: 'explicit' }],
@@ -47,7 +39,6 @@ describe('erd confidence policy', () => {
     expect(evaluated.markerRequired).to.equal(true);
     expect(evaluated.counts.inferenceShare).to.equal(0.6667);
   });
-
   it('classifies fail_confidence when no explicit entities are available', () => {
     const evaluated = evaluateErdConfidence({ entities: [], relationships: [] });
     expect(evaluated.outcome).to.equal('fail_confidence');

--- a/test/erd-confidence.test.js
+++ b/test/erd-confidence.test.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const { evaluateErdConfidence } = require('../src/schema/erd-confidence');
+
+describe('erd confidence policy', () => {
+  it('classifies publishable when explicit entities exist and inference share is low', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('publishable');
+    expect(evaluated.shouldFail).to.equal(false);
+    expect(evaluated.counts.inferenceShare).to.equal(0);
+  });
+
+  it('classifies publishable_with_marker when inferred relationships dominate but stay <= 0.8', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+        { name: 'COMMENT', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+        { fromEntity: 'COMMENT', toEntity: 'USER', provenance: 'inferred' },
+        { fromEntity: 'COMMENT', toEntity: 'SESSION', provenance: 'inferred' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('publishable_with_marker');
+    expect(evaluated.markerRequired).to.equal(true);
+    expect(evaluated.counts.inferenceShare).to.equal(0.6667);
+  });
+
+  it('classifies fail_confidence when no explicit entities are available', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [],
+      relationships: [],
+    });
+
+    expect(evaluated.outcome).to.equal('fail_confidence');
+    expect(evaluated.shouldFail).to.equal(true);
+  });
+});

--- a/test/erd-confidence.test.js
+++ b/test/erd-confidence.test.js
@@ -1,106 +1,55 @@
 const { expect } = require('chai');
 const { evaluateErdConfidence } = require('../src/schema/erd-confidence');
 
+function evaluateShare({ inferred, explicit }) {
+  const relationships = [
+    ...Array.from({ length: explicit }, () => ({ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' })),
+    ...Array.from({ length: inferred }, () => ({ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' })),
+  ];
+  return evaluateErdConfidence({ entities: [{ name: 'USER', source: 'explicit' }], relationships });
+}
+
 describe('erd confidence policy', () => {
   it('classifies publishable when explicit entities exist and inference share is low', () => {
     const evaluated = evaluateErdConfidence({
-      entities: [
-        { name: 'USER', source: 'explicit' },
-        { name: 'SESSION', source: 'explicit' },
-      ],
-      relationships: [
-        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
-      ],
+      entities: [{ name: 'USER', source: 'explicit' }, { name: 'SESSION', source: 'explicit' }],
+      relationships: [{ fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' }],
     });
-
     expect(evaluated.outcome).to.equal('publishable');
     expect(evaluated.shouldFail).to.equal(false);
     expect(evaluated.counts.inferenceShare).to.equal(0);
   });
 
+  it('handles boundary thresholds at 0.5, 0.8, and >0.8 inference share', () => {
+    const cases = [
+      { inferred: 1, explicit: 1, outcome: 'publishable', markerRequired: false, inferenceShare: 0.5 },
+      { inferred: 4, explicit: 1, outcome: 'publishable_with_marker', markerRequired: true, inferenceShare: 0.8 },
+      { inferred: 5, explicit: 1, outcome: 'fail_confidence', markerRequired: false, inferenceShare: 0.8333 },
+    ];
+    for (const expected of cases) {
+      const evaluated = evaluateShare(expected);
+      expect(evaluated.outcome).to.equal(expected.outcome);
+      expect(evaluated.markerRequired).to.equal(expected.markerRequired);
+      expect(evaluated.counts.inferenceShare).to.equal(expected.inferenceShare);
+    }
+  });
+
   it('classifies publishable_with_marker when inferred relationships dominate but stay <= 0.8', () => {
     const evaluated = evaluateErdConfidence({
-      entities: [
-        { name: 'USER', source: 'explicit' },
-        { name: 'SESSION', source: 'explicit' },
-        { name: 'COMMENT', source: 'explicit' },
-      ],
+      entities: [{ name: 'USER', source: 'explicit' }, { name: 'SESSION', source: 'explicit' }, { name: 'COMMENT', source: 'explicit' }],
       relationships: [
         { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
         { fromEntity: 'COMMENT', toEntity: 'USER', provenance: 'inferred' },
         { fromEntity: 'COMMENT', toEntity: 'SESSION', provenance: 'inferred' },
       ],
     });
-
     expect(evaluated.outcome).to.equal('publishable_with_marker');
     expect(evaluated.markerRequired).to.equal(true);
     expect(evaluated.counts.inferenceShare).to.equal(0.6667);
   });
 
-  it('keeps publishable at inferenceShare boundary 0.5', () => {
-    const evaluated = evaluateErdConfidence({
-      entities: [
-        { name: 'USER', source: 'explicit' },
-        { name: 'SESSION', source: 'explicit' },
-      ],
-      relationships: [
-        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
-        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
-      ],
-    });
-
-    expect(evaluated.outcome).to.equal('publishable');
-    expect(evaluated.markerRequired).to.equal(false);
-    expect(evaluated.counts.inferenceShare).to.equal(0.5);
-  });
-
-  it('marks publishable_with_marker at inferenceShare boundary 0.8', () => {
-    const evaluated = evaluateErdConfidence({
-      entities: [
-        { name: 'USER', source: 'explicit' },
-        { name: 'SESSION', source: 'explicit' },
-      ],
-      relationships: [
-        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
-        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
-        { fromEntity: 'USER', toEntity: 'USER', provenance: 'inferred' },
-        { fromEntity: 'SESSION', toEntity: 'SESSION', provenance: 'inferred' },
-        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' },
-      ],
-    });
-
-    expect(evaluated.outcome).to.equal('publishable_with_marker');
-    expect(evaluated.markerRequired).to.equal(true);
-    expect(evaluated.counts.inferenceShare).to.equal(0.8);
-  });
-
-  it('fails confidence when inferenceShare is greater than 0.8', () => {
-    const evaluated = evaluateErdConfidence({
-      entities: [
-        { name: 'USER', source: 'explicit' },
-        { name: 'SESSION', source: 'explicit' },
-      ],
-      relationships: [
-        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
-        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
-        { fromEntity: 'USER', toEntity: 'USER', provenance: 'inferred' },
-        { fromEntity: 'SESSION', toEntity: 'SESSION', provenance: 'inferred' },
-        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'inferred' },
-        { fromEntity: 'USER', toEntity: 'SESSION', provenance: 'inferred' },
-      ],
-    });
-
-    expect(evaluated.outcome).to.equal('fail_confidence');
-    expect(evaluated.markerRequired).to.equal(false);
-    expect(evaluated.counts.inferenceShare).to.equal(0.8333);
-  });
-
   it('classifies fail_confidence when no explicit entities are available', () => {
-    const evaluated = evaluateErdConfidence({
-      entities: [],
-      relationships: [],
-    });
-
+    const evaluated = evaluateErdConfidence({ entities: [], relationships: [] });
     expect(evaluated.outcome).to.equal('fail_confidence');
     expect(evaluated.shouldFail).to.equal(true);
     expect(evaluated.markerRequired).to.equal(false);


### PR DESCRIPTION
# Pull request checklist

## Summary

- What changed (brief): Added ERD confidence/model foundation (`erd-model`, `erd-confidence`, unit tests) and included requested path updates in `docs/agents/06-contradictions-and-cleanup.md` and `scripts/check-environment.sh`.
- Why this change was needed: Break the ERD feature into risk-gate-compliant slices while preserving correctness and including your requested environment/docs corrections.
- Risk and rollback plan: Low-to-medium. Changes are additive and covered by tests; rollback by reverting commit `6a53033`.

## Checklist

- [x] I did not push directly to `main`; this PR is from a dedicated branch.
- [x] Branch name follows policy (`codex/*` for agent-created branches).
- [ ] **(Pending)** Required local gates run: `npm test`, `npm run test:deep`, `npm run harness:check`.
- [ ] **(Pending)** Greptile review completed and findings handled (or explicitly waived).
- [ ] **(Pending)** Greptile review was performed by an independent reviewer (not the coding agent).
- [ ] **(Pending)** Greptile confidence score is `>= 4/5` for merge eligibility.
- [ ] **(Pending)** Codex review completed and findings handled (or explicitly waived).
- [x] Merge is blocked until all required checks pass.
- [x] I will delete branch/worktree after merge.

## Testing

- verification_commands: `npm test`; `npm run test:deep`; `npm run harness:check`
- verification_outcomes: `npm test` pass; `npm run test:deep` pass; `npm run harness:check` fail (memory-gate closeout flag requirement)
- blocked_steps_reason: local `harness:check` is blocked by `FORJAMIE.md update flag not set in closeout` memory-gate policy
- Command: `npm test` -> pass
- Command: `npm run test:deep` -> pass
- Command: `npm run harness:check` -> fail (memory-gate closeout flag)
- Any other command(s): `source scripts/codex-preflight.sh && preflight_repo` -> pass

## Review artifacts

- Greptile: pending
- Greptile confidence score: pending
- Independent reviewer evidence: pending
- Codex: pending
- Additional evidence (if any): n/a

## Notes

This PR is slice 1 of the ERD rollout and is intentionally kept under diff-budget limits; subsequent slices will layer extractor/integration work on top once this baseline lands.
