### PR TITLE
feat: add prisma ERD extractor foundation

### DIFF
--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -1,0 +1,233 @@
+const fs = require('fs');
+const path = require('path');
+const { globSync } = require('glob');
+const { canonicalEntityName, normalizeErdModel } = require('./erd-model');
+
+const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'];
+const SOURCE_PRECEDENCE = Object.freeze(['prisma']);
+const PRISMA_SCALAR_TYPES = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes']);
+
+function parsePrismaField(line) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('@@')) return null;
+  const parts = trimmed.split(/\s+/);
+  if (parts.length < 2) return null;
+
+  const name = parts[0];
+  const rawType = parts[1];
+  const rest = parts.slice(2).join(' ');
+  const isArray = rawType.endsWith('[]');
+  const nullable = rawType.endsWith('?');
+  const baseType = rawType.replace(/\?$/, '').replace(/\[\]$/, '');
+  const keyFlags = [];
+
+  if (/\@id\b/.test(rest)) keyFlags.push('PK');
+  if (/\@unique\b/.test(rest)) keyFlags.push('UK');
+
+  const relationMatch = rest.match(/\@relation\s*\(([\s\S]*?)\)/);
+  const relationMeta = relationMatch ? relationMatch[1] : '';
+  const fieldListMatch = relationMeta.match(/fields\s*:\s*\[([^\]]+)\]/i);
+  const relationFields = fieldListMatch
+    ? fieldListMatch[1]
+      .split(',')
+      .map((field) => field.trim())
+      .filter(Boolean)
+    : [];
+
+  const isRelationType = /^[A-Z]/.test(baseType) && !PRISMA_SCALAR_TYPES.has(baseType);
+
+  return {
+    name,
+    type: baseType,
+    nullable,
+    isArray,
+    isRelationType,
+    relationFields,
+    keyFlags,
+  };
+}
+
+function parsePrismaSchema(fileContent) {
+  const entities = [];
+  const relationships = [];
+  const modelRe = /\bmodel\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{([\s\S]*?)\}/g;
+  let match;
+
+  while ((match = modelRe.exec(fileContent)) !== null) {
+    const modelName = match[1];
+    const body = match[2];
+    const fields = body.split(/\r?\n/).map(parsePrismaField).filter(Boolean);
+    const attributes = fields
+      .filter((field) => !field.isRelationType)
+      .map((field) => ({
+        name: field.name,
+        type: field.type,
+        nullable: field.nullable,
+        keyFlags: [...field.keyFlags],
+      }));
+    const attributesByName = new Map(attributes.map((attribute) => [attribute.name, attribute]));
+
+    for (const field of fields) {
+      for (const relationField of field.relationFields) {
+        const attribute = attributesByName.get(relationField);
+        if (attribute && !attribute.keyFlags.includes('FK')) {
+          attribute.keyFlags.push('FK');
+        }
+      }
+    }
+
+    entities.push({
+      name: modelName,
+      source: 'explicit',
+      attributes,
+    });
+
+    for (const field of fields) {
+      if (!field.isRelationType) continue;
+      if ((field.relationFields || []).length === 0) continue;
+      const cardinality = field.isArray ? '||--o{' : '}o--||';
+      relationships.push({
+        fromEntity: modelName,
+        toEntity: field.type,
+        cardinality,
+        provenance: 'explicit',
+      });
+    }
+  }
+
+  return { entities, relationships };
+}
+
+function inferRelationshipsFromForeignKeyNames(entities, explicitRelationships) {
+  const byEntity = new Map(entities.map((entity) => [canonicalEntityName(entity.name), entity]));
+  const explicitKeys = new Set(
+    explicitRelationships.map((relationship) => {
+      const from = canonicalEntityName(relationship.fromEntity);
+      const to = canonicalEntityName(relationship.toEntity);
+      return `${from}|${to}`;
+    })
+  );
+
+  const inferred = [];
+  for (const entity of entities) {
+    const from = canonicalEntityName(entity.name);
+    for (const attribute of entity.attributes || []) {
+      const attributeName = String(attribute.name || '');
+      if (!/(?:_id|Id)$/.test(attributeName)) continue;
+      const rawBase = attributeName.replace(/(?:_id|Id)$/, '');
+      if (!rawBase) continue;
+      const candidates = [
+        canonicalEntityName(rawBase),
+        canonicalEntityName(`${rawBase}s`),
+        canonicalEntityName(rawBase.endsWith('s') ? rawBase.slice(0, -1) : rawBase),
+      ].filter(Boolean);
+
+      const target = candidates.find((candidate) => byEntity.has(candidate));
+      if (!target) continue;
+      const key = `${from}|${target}`;
+      if (explicitKeys.has(key)) continue;
+      explicitKeys.add(key);
+      inferred.push({
+        fromEntity: from,
+        toEntity: target,
+        cardinality: '}o--||',
+        provenance: 'inferred',
+      });
+    }
+  }
+
+  return inferred;
+}
+
+function extractErdModel({ rootPath }) {
+  const result = {
+    extractionInvoked: true,
+    sourcePrecedence: [...SOURCE_PRECEDENCE],
+    sourceFiles: [],
+    diagnostics: [],
+    terminalClass: 'completed',
+    model: normalizeErdModel({ entities: [], relationships: [] }),
+  };
+
+  if (!rootPath || !fs.existsSync(rootPath)) {
+    result.terminalClass = 'failed_parse';
+    result.diagnostics.push('root path is missing or does not exist');
+    return result;
+  }
+
+  const prismaFiles = globSync('**/schema.prisma', {
+    cwd: rootPath,
+    absolute: true,
+    ignore: DEFAULT_IGNORE,
+    nodir: true,
+  }).sort();
+
+  const entities = [];
+  const relationships = [];
+  const parseErrors = [];
+
+  for (const filePath of prismaFiles) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const parsed = parsePrismaSchema(content);
+      entities.push(...parsed.entities);
+      relationships.push(...parsed.relationships);
+      result.sourceFiles.push(path.relative(rootPath, filePath));
+    } catch (error) {
+      parseErrors.push({
+        source: 'prisma',
+        file: path.relative(rootPath, filePath),
+        message: error.message,
+      });
+    }
+  }
+
+  const normalized = normalizeErdModel({
+    entities,
+    relationships,
+    sourceFiles: result.sourceFiles,
+    diagnostics: [],
+    sourcePrecedence: SOURCE_PRECEDENCE,
+  });
+
+  const inferredRelationships = inferRelationshipsFromForeignKeyNames(
+    normalized.entities,
+    normalized.relationships
+  );
+  const model = normalizeErdModel({
+    ...normalized,
+    relationships: [...normalized.relationships, ...inferredRelationships],
+    sourcePrecedence: SOURCE_PRECEDENCE,
+  });
+
+  if (result.sourceFiles.length === 0 && parseErrors.length === 0) {
+    result.terminalClass = 'failed_no_schema';
+    result.diagnostics.push('no supported schema sources found (expected schema.prisma files)');
+  } else if (model.entities.length === 0) {
+    result.terminalClass = 'failed_parse';
+    if (parseErrors.length > 0) {
+      result.diagnostics.push(
+        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
+      );
+    } else {
+      result.diagnostics.push(
+        'schema sources found but no ERD entities extracted (check supported model shapes)'
+      );
+    }
+  } else {
+    if (parseErrors.length > 0) {
+      result.diagnostics.push(
+        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
+      );
+    }
+    result.terminalClass = 'completed';
+  }
+
+  result.model = model;
+  return result;
+}
+
+module.exports = {
+  SOURCE_PRECEDENCE,
+  extractErdModel,
+};

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const path = require('path');
+const { SOURCE_PRECEDENCE, extractErdModel } = require('../src/schema/erd-extractor');
+
+function fixturePath(name) {
+  return path.join(__dirname, 'fixtures', 'erd', name);
+}
+
+describe('erd extractor', () => {
+  it('extracts explicit Prisma entities, keys, and relationships', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('explicit-schema') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.sourcePrecedence).to.deep.equal(SOURCE_PRECEDENCE);
+    expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['TICKET', 'USER']);
+
+    const ticket = extracted.model.entities.find((entity) => entity.name === 'TICKET');
+    expect(ticket).to.exist;
+    const authorId = ticket.attributes.find((attribute) => attribute.name === 'authorId');
+    expect(authorId).to.exist;
+    expect(authorId.keyFlags).to.include('FK');
+
+    const user = extracted.model.entities.find((entity) => entity.name === 'USER');
+    const email = user.attributes.find((attribute) => attribute.name === 'email');
+    expect(email.keyFlags).to.include('UK');
+
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'TICKET'
+      && relationship.toEntity === 'USER'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'USER'
+      && relationship.toEntity === 'TICKET'
+      && relationship.provenance === 'explicit'
+    )).to.equal(false);
+  });
+
+  it('marks missing schema sources with failed_no_schema', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('no-schema') });
+
+    expect(extracted.terminalClass).to.equal('failed_no_schema');
+    expect(extracted.model.entities).to.have.length(0);
+    expect(extracted.diagnostics[0]).to.include('no supported schema sources found');
+  });
+});

--- a/test/fixtures/erd/explicit-schema/prisma/schema.prisma
+++ b/test/fixtures/erd/explicit-schema/prisma/schema.prisma
@@ -1,0 +1,12 @@
+model User {
+  id Int @id @default(autoincrement())
+  email String @unique
+  tickets Ticket[]
+}
+
+model Ticket {
+  id Int @id @default(autoincrement())
+  title String
+  authorId Int
+  author User @relation(fields: [authorId], references: [id])
+}

--- a/test/fixtures/erd/no-schema/src/index.js
+++ b/test/fixtures/erd/no-schema/src/index.js
@@ -1,0 +1,3 @@
+export function boot() {
+  return 'no schema here';
+}


### PR DESCRIPTION
# Pull request checklist

## Summary

- What changed (brief): Added a Prisma-first ERD extractor (`src/schema/erd-extractor.js`) with explicit key extraction, explicit relation extraction, inferred FK-name relation fallback, and extractor fixtures/tests.
- Why this change was needed: This is slice 2 of the ERD rollout and keeps the delta within risk-policy diff-budget while making schema extraction testable in isolation.
- Risk and rollback plan: Low-to-medium. Additive files only; rollback by reverting commit `4decb77`.

## Checklist

- [x] I did not push directly to `main`; this PR is from a dedicated branch.
- [x] Branch name follows policy (`codex/*` for agent-created branches).
- [ ] **(Pending)** Required local gates run: `npm test`, `npm run test:deep`, `npm run harness:check`.
- [ ] **(Pending)** Greptile review completed and findings handled (or explicitly waived).
- [ ] **(Pending)** Greptile review was performed by an independent reviewer (not the coding agent).
- [ ] **(Pending)** Greptile confidence score is `>= 4/5` for merge eligibility.
- [ ] **(Pending)** Codex review completed and findings handled (or explicitly waived).
- [x] Merge is blocked until all required checks pass.
- [x] I will delete branch/worktree after merge.

## Testing

- verification_commands: `npm test`; `npm run test:deep`; `npm run harness:check`
- verification_outcomes: `npm test` pass; `npm run test:deep` pass; `npm run harness:check` fail (memory-gate closeout flag requirement)
- blocked_steps_reason: local `harness:check` remains blocked by `FORJAMIE.md update flag not set in closeout` memory-gate policy
- Command: `npm test` -> pass
- Command: `npm run test:deep` -> pass
- Command: `npm run harness:check` -> fail (memory-gate closeout flag)
- Any other command(s): none

## Review artifacts

- Greptile: pending
- Greptile confidence score: pending
- Independent reviewer evidence: pending
- Codex: pending
- Additional evidence (if any): n/a

## Notes

Stacked PR: base branch is `codex/erd-slice-1-model-confidence` (PR #58). Merge #58 first, then retarget this PR to `main` if needed.
