### PR TITLE
feat: add SQL basics to ERD extractor

### DIFF
--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -5,9 +5,18 @@ const { canonicalEntityName, normalizeErdModel } = require('./erd-model');
 
 const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'];
 const SOURCE_PRECEDENCE = Object.freeze(['prisma', 'sql']);
+const SOURCE_FILE_PATTERNS = Object.freeze({
+  prisma: '**/schema.prisma',
+  sql: '**/*.sql',
+});
 const PRISMA_SCALAR_TYPES = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes']);
 const SQL_IDENTIFIER_SOURCE = '(?:["`][^"`]+["`]|[A-Za-z_][A-Za-z0-9_]*)';
 const SQL_QUALIFIED_IDENTIFIER_SOURCE = `${SQL_IDENTIFIER_SOURCE}(?:\\s*\\.\\s*${SQL_IDENTIFIER_SOURCE})?`;
+const SQL_CREATE_TABLE_RE = new RegExp(
+  `\\bcreate\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?(${SQL_QUALIFIED_IDENTIFIER_SOURCE})\\s*\\(([\\s\\S]*?)\\)\\s*(?:;|(?=\\s*(?:create\\s+table\\b|$)))`,
+  'gi'
+);
+const SQL_INLINE_REFERENCES_RE = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -128,14 +137,10 @@ function tableNameFromSql(token) {
 function parseSqlSchema(fileContent) {
   const entities = [];
   const relationships = [];
-  const createTableRe = new RegExp(
-    `\\bcreate\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?(${SQL_QUALIFIED_IDENTIFIER_SOURCE})\\s*\\(([\\s\\S]*?)\\)\\s*(?:;|(?=\\s*(?:create\\s+table\\b|$)))`,
-    'gi'
-  );
-  const inlineReferencesRe = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
   let tableMatch;
+  SQL_CREATE_TABLE_RE.lastIndex = 0;
 
-  while ((tableMatch = createTableRe.exec(fileContent)) !== null) {
+  while ((tableMatch = SQL_CREATE_TABLE_RE.exec(fileContent)) !== null) {
     const tableName = tableNameFromSql(tableMatch[1]);
     const body = tableMatch[2];
     const definitions = splitSqlDefinitions(body);
@@ -146,7 +151,7 @@ function parseSqlSchema(fileContent) {
       if (!line) continue;
 
       if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
-        const fkConstraint = line.match(inlineReferencesRe);
+        const fkConstraint = line.match(SQL_INLINE_REFERENCES_RE);
         if (fkConstraint) {
           relationships.push({
             fromEntity: tableName,
@@ -169,7 +174,7 @@ function parseSqlSchema(fileContent) {
       if (/\bprimary\s+key\b/i.test(remainder)) keyFlags.push('PK');
       if (/\bunique\b/i.test(remainder)) keyFlags.push('UK');
 
-      const referencesMatch = remainder.match(inlineReferencesRe);
+      const referencesMatch = remainder.match(SQL_INLINE_REFERENCES_RE);
       if (referencesMatch) {
         keyFlags.push('FK');
         relationships.push({
@@ -196,6 +201,17 @@ function parseSqlSchema(fileContent) {
   }
 
   return { entities, relationships };
+}
+
+function parseSchemaSource(source, content) {
+  if (source === 'prisma') return parsePrismaSchema(content);
+  if (source === 'sql') return parseSqlSchema(content);
+  throw new Error(`unsupported schema source: ${source}`);
+}
+
+function appendParseDiagnostics(diagnostics, parseErrors) {
+  if (parseErrors.length === 0) return;
+  diagnostics.push(...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`));
 }
 
 function inferRelationshipsFromForeignKeyNames(entities, explicitRelationships) {
@@ -255,19 +271,17 @@ function extractErdModel({ rootPath }) {
     return result;
   }
 
-  const prismaFiles = globSync('**/schema.prisma', {
-    cwd: rootPath,
-    absolute: true,
-    ignore: DEFAULT_IGNORE,
-    nodir: true,
-  }).sort();
-  const sqlFiles = globSync('**/*.sql', {
-    cwd: rootPath,
-    absolute: true,
-    ignore: DEFAULT_IGNORE,
-    nodir: true,
-  }).sort();
-  const sourceCandidates = { prisma: prismaFiles, sql: sqlFiles };
+  const sourceCandidates = Object.fromEntries(
+    SOURCE_PRECEDENCE.map((source) => [
+      source,
+      globSync(SOURCE_FILE_PATTERNS[source], {
+        cwd: rootPath,
+        absolute: true,
+        ignore: DEFAULT_IGNORE,
+        nodir: true,
+      }).sort(),
+    ])
+  );
 
   const entities = [];
   const relationships = [];
@@ -278,7 +292,7 @@ function extractErdModel({ rootPath }) {
     for (const filePath of files) {
       try {
         const content = fs.readFileSync(filePath, 'utf8');
-        const parsed = source === 'prisma' ? parsePrismaSchema(content) : parseSqlSchema(content);
+        const parsed = parseSchemaSource(source, content);
         entities.push(...parsed.entities);
         relationships.push(...parsed.relationships);
         result.sourceFiles.push(path.relative(rootPath, filePath));
@@ -315,21 +329,14 @@ function extractErdModel({ rootPath }) {
     result.diagnostics.push('no supported schema sources found (expected schema.prisma or .sql files)');
   } else if (model.entities.length === 0) {
     result.terminalClass = 'failed_parse';
-    if (parseErrors.length > 0) {
-      result.diagnostics.push(
-        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
-      );
-    } else {
+    if (parseErrors.length === 0) {
       result.diagnostics.push(
         'schema sources found but no ERD entities extracted (check supported model shapes)'
       );
     }
+    appendParseDiagnostics(result.diagnostics, parseErrors);
   } else {
-    if (parseErrors.length > 0) {
-      result.diagnostics.push(
-        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
-      );
-    }
+    appendParseDiagnostics(result.diagnostics, parseErrors);
     result.terminalClass = 'completed';
   }
 

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -23,6 +23,7 @@ const SQL_TABLE_FOREIGN_KEY_RE = new RegExp(
   `^(?:constraint\\s+\\S+\\s+)?foreign\\s+key\\s*\\(([^)]+)\\)\\s+references\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`,
   'i'
 );
+const SQL_TABLE_CONSTRAINT_LINE_RE = /^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i;
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -157,6 +158,17 @@ function addSqlKeyFlags(attributeMap, columns, flag) {
   }
 }
 
+function pushExplicitSqlRelationship(relationships, fromEntity, toEntityToken) {
+  const toEntity = tableNameFromSql(toEntityToken);
+  if (!toEntity) return;
+  relationships.push({
+    fromEntity,
+    toEntity,
+    cardinality: '}o--||',
+    provenance: 'explicit',
+  });
+}
+
 function applyTableConstraint(line, tableName, attributeMap, relationships) {
   const primaryMatch = line.match(SQL_TABLE_PRIMARY_KEY_RE);
   if (primaryMatch) {
@@ -174,12 +186,7 @@ function applyTableConstraint(line, tableName, attributeMap, relationships) {
   if (!foreignKeyMatch) return;
 
   addSqlKeyFlags(attributeMap, parseSqlIdentifierList(foreignKeyMatch[1]), 'FK');
-  relationships.push({
-    fromEntity: tableName,
-    toEntity: tableNameFromSql(foreignKeyMatch[2]),
-    cardinality: '}o--||',
-    provenance: 'explicit',
-  });
+  pushExplicitSqlRelationship(relationships, tableName, foreignKeyMatch[2]);
 }
 
 function parseSqlSchema(fileContent) {
@@ -199,7 +206,7 @@ function parseSqlSchema(fileContent) {
       const line = definition.trim();
       if (!line) continue;
 
-      if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
+      if (SQL_TABLE_CONSTRAINT_LINE_RE.test(line)) {
         tableConstraints.push(line);
         continue;
       }
@@ -218,12 +225,7 @@ function parseSqlSchema(fileContent) {
       const referencesMatch = remainder.match(SQL_INLINE_REFERENCES_RE);
       if (referencesMatch) {
         keyFlags.push('FK');
-        relationships.push({
-          fromEntity: tableName,
-          toEntity: tableNameFromSql(referencesMatch[1]),
-          cardinality: '}o--||',
-          provenance: 'explicit',
-        });
+        pushExplicitSqlRelationship(relationships, tableName, referencesMatch[1]);
       }
 
       attributes.push({
@@ -234,11 +236,13 @@ function parseSqlSchema(fileContent) {
       });
     }
 
-    const attributeMap = new Map(
-      attributes.map((attribute) => [String(attribute.name).toLowerCase(), attribute])
-    );
-    for (const constraintLine of tableConstraints) {
-      applyTableConstraint(constraintLine, tableName, attributeMap, relationships);
+    if (tableConstraints.length > 0) {
+      const attributeMap = new Map(
+        attributes.map((attribute) => [String(attribute.name).toLowerCase(), attribute])
+      );
+      for (const constraintLine of tableConstraints) {
+        applyTableConstraint(constraintLine, tableName, attributeMap, relationships);
+      }
     }
 
     entities.push({

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -4,8 +4,10 @@ const { globSync } = require('glob');
 const { canonicalEntityName, normalizeErdModel } = require('./erd-model');
 
 const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'];
-const SOURCE_PRECEDENCE = Object.freeze(['prisma']);
+const SOURCE_PRECEDENCE = Object.freeze(['prisma', 'sql']);
 const PRISMA_SCALAR_TYPES = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes']);
+const SQL_IDENTIFIER_SOURCE = '(?:["`][^"`]+["`]|[A-Za-z_][A-Za-z0-9_]*)';
+const SQL_QUALIFIED_IDENTIFIER_SOURCE = `${SQL_IDENTIFIER_SOURCE}(?:\\s*\\.\\s*${SQL_IDENTIFIER_SOURCE})?`;
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -98,6 +100,104 @@ function parsePrismaSchema(fileContent) {
   return { entities, relationships };
 }
 
+function splitSqlDefinitions(body) {
+  const chunks = [];
+  let cursor = '';
+  let depth = 0;
+  for (const char of body) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth = Math.max(0, depth - 1);
+    if (char === ',' && depth === 0) {
+      chunks.push(cursor.trim());
+      cursor = '';
+      continue;
+    }
+    cursor += char;
+  }
+  if (cursor.trim()) chunks.push(cursor.trim());
+  return chunks;
+}
+
+function tableNameFromSql(token) {
+  const normalized = String(token || '').trim().replace(/\s*\.\s*/g, '.');
+  if (!normalized) return '';
+  const base = normalized.split('.').pop() || normalized;
+  return base.replace(/^["`]/, '').replace(/["`]$/, '');
+}
+
+function parseSqlSchema(fileContent) {
+  const entities = [];
+  const relationships = [];
+  const createTableRe = new RegExp(
+    `\\bcreate\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?(${SQL_QUALIFIED_IDENTIFIER_SOURCE})\\s*\\(([\\s\\S]*?)\\)\\s*(?:;|(?=\\s*(?:create\\s+table\\b|$)))`,
+    'gi'
+  );
+  const inlineReferencesRe = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
+  let tableMatch;
+
+  while ((tableMatch = createTableRe.exec(fileContent)) !== null) {
+    const tableName = tableNameFromSql(tableMatch[1]);
+    const body = tableMatch[2];
+    const definitions = splitSqlDefinitions(body);
+    const attributes = [];
+
+    for (const definition of definitions) {
+      const line = definition.trim();
+      if (!line) continue;
+
+      if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
+        const fkConstraint = line.match(inlineReferencesRe);
+        if (fkConstraint) {
+          relationships.push({
+            fromEntity: tableName,
+            toEntity: tableNameFromSql(fkConstraint[1]),
+            cardinality: '}o--||',
+            provenance: 'explicit',
+          });
+        }
+        continue;
+      }
+
+      const columnMatch = line.match(/^([`"]?[A-Za-z_][A-Za-z0-9_]*[`"]?)\s+([A-Za-z0-9_()]+)([\s\S]*)$/);
+      if (!columnMatch) continue;
+      const columnName = tableNameFromSql(columnMatch[1]);
+      const columnType = columnMatch[2];
+      const remainder = columnMatch[3] || '';
+      const remainderLower = remainder.toLowerCase();
+      const keyFlags = [];
+
+      if (/\bprimary\s+key\b/i.test(remainder)) keyFlags.push('PK');
+      if (/\bunique\b/i.test(remainder)) keyFlags.push('UK');
+
+      const referencesMatch = remainder.match(inlineReferencesRe);
+      if (referencesMatch) {
+        keyFlags.push('FK');
+        relationships.push({
+          fromEntity: tableName,
+          toEntity: tableNameFromSql(referencesMatch[1]),
+          cardinality: '}o--||',
+          provenance: 'explicit',
+        });
+      }
+
+      attributes.push({
+        name: columnName,
+        type: columnType.toLowerCase(),
+        nullable: !/\bnot\s+null\b/.test(remainderLower),
+        keyFlags,
+      });
+    }
+
+    entities.push({
+      name: tableName,
+      source: 'explicit',
+      attributes,
+    });
+  }
+
+  return { entities, relationships };
+}
+
 function inferRelationshipsFromForeignKeyNames(entities, explicitRelationships) {
   const byEntity = new Map(entities.map((entity) => [canonicalEntityName(entity.name), entity]));
   const explicitKeys = new Set(
@@ -161,24 +261,34 @@ function extractErdModel({ rootPath }) {
     ignore: DEFAULT_IGNORE,
     nodir: true,
   }).sort();
+  const sqlFiles = globSync('**/*.sql', {
+    cwd: rootPath,
+    absolute: true,
+    ignore: DEFAULT_IGNORE,
+    nodir: true,
+  }).sort();
+  const sourceCandidates = { prisma: prismaFiles, sql: sqlFiles };
 
   const entities = [];
   const relationships = [];
   const parseErrors = [];
 
-  for (const filePath of prismaFiles) {
-    try {
-      const content = fs.readFileSync(filePath, 'utf8');
-      const parsed = parsePrismaSchema(content);
-      entities.push(...parsed.entities);
-      relationships.push(...parsed.relationships);
-      result.sourceFiles.push(path.relative(rootPath, filePath));
-    } catch (error) {
-      parseErrors.push({
-        source: 'prisma',
-        file: path.relative(rootPath, filePath),
-        message: error.message,
-      });
+  for (const source of SOURCE_PRECEDENCE) {
+    const files = sourceCandidates[source] || [];
+    for (const filePath of files) {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const parsed = source === 'prisma' ? parsePrismaSchema(content) : parseSqlSchema(content);
+        entities.push(...parsed.entities);
+        relationships.push(...parsed.relationships);
+        result.sourceFiles.push(path.relative(rootPath, filePath));
+      } catch (error) {
+        parseErrors.push({
+          source,
+          file: path.relative(rootPath, filePath),
+          message: error.message,
+        });
+      }
     }
   }
 
@@ -202,7 +312,7 @@ function extractErdModel({ rootPath }) {
 
   if (result.sourceFiles.length === 0 && parseErrors.length === 0) {
     result.terminalClass = 'failed_no_schema';
-    result.diagnostics.push('no supported schema sources found (expected schema.prisma files)');
+    result.diagnostics.push('no supported schema sources found (expected schema.prisma or .sql files)');
   } else if (model.entities.length === 0) {
     result.terminalClass = 'failed_parse';
     if (parseErrors.length > 0) {

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -17,6 +17,12 @@ const SQL_CREATE_TABLE_RE = new RegExp(
   'gi'
 );
 const SQL_INLINE_REFERENCES_RE = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
+const SQL_TABLE_PRIMARY_KEY_RE = /^(?:constraint\s+\S+\s+)?primary\s+key\s*\(([^)]+)\)/i;
+const SQL_TABLE_UNIQUE_RE = /^(?:constraint\s+\S+\s+)?unique\s*\(([^)]+)\)/i;
+const SQL_TABLE_FOREIGN_KEY_RE = new RegExp(
+  `^(?:constraint\\s+\\S+\\s+)?foreign\\s+key\\s*\\(([^)]+)\\)\\s+references\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`,
+  'i'
+);
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -134,6 +140,48 @@ function tableNameFromSql(token) {
   return base.replace(/^["`]/, '').replace(/["`]$/, '');
 }
 
+function parseSqlIdentifierList(tokenList) {
+  return String(tokenList || '')
+    .split(',')
+    .map((token) => tableNameFromSql(token))
+    .filter(Boolean);
+}
+
+function addSqlKeyFlags(attributeMap, columns, flag) {
+  for (const column of columns) {
+    const attribute = attributeMap.get(String(column).toLowerCase());
+    if (!attribute) continue;
+    if (!attribute.keyFlags.includes(flag)) {
+      attribute.keyFlags.push(flag);
+    }
+  }
+}
+
+function applyTableConstraint(line, tableName, attributeMap, relationships) {
+  const primaryMatch = line.match(SQL_TABLE_PRIMARY_KEY_RE);
+  if (primaryMatch) {
+    addSqlKeyFlags(attributeMap, parseSqlIdentifierList(primaryMatch[1]), 'PK');
+    return;
+  }
+
+  const uniqueMatch = line.match(SQL_TABLE_UNIQUE_RE);
+  if (uniqueMatch) {
+    addSqlKeyFlags(attributeMap, parseSqlIdentifierList(uniqueMatch[1]), 'UK');
+    return;
+  }
+
+  const foreignKeyMatch = line.match(SQL_TABLE_FOREIGN_KEY_RE);
+  if (!foreignKeyMatch) return;
+
+  addSqlKeyFlags(attributeMap, parseSqlIdentifierList(foreignKeyMatch[1]), 'FK');
+  relationships.push({
+    fromEntity: tableName,
+    toEntity: tableNameFromSql(foreignKeyMatch[2]),
+    cardinality: '}o--||',
+    provenance: 'explicit',
+  });
+}
+
 function parseSqlSchema(fileContent) {
   const entities = [];
   const relationships = [];
@@ -145,21 +193,14 @@ function parseSqlSchema(fileContent) {
     const body = tableMatch[2];
     const definitions = splitSqlDefinitions(body);
     const attributes = [];
+    const tableConstraints = [];
 
     for (const definition of definitions) {
       const line = definition.trim();
       if (!line) continue;
 
       if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
-        const fkConstraint = line.match(SQL_INLINE_REFERENCES_RE);
-        if (fkConstraint) {
-          relationships.push({
-            fromEntity: tableName,
-            toEntity: tableNameFromSql(fkConstraint[1]),
-            cardinality: '}o--||',
-            provenance: 'explicit',
-          });
-        }
+        tableConstraints.push(line);
         continue;
       }
 
@@ -191,6 +232,13 @@ function parseSqlSchema(fileContent) {
         nullable: !/\bnot\s+null\b/.test(remainderLower),
         keyFlags,
       });
+    }
+
+    const attributeMap = new Map(
+      attributes.map((attribute) => [String(attribute.name).toLowerCase(), attribute])
+    );
+    for (const constraintLine of tableConstraints) {
+      applyTableConstraint(constraintLine, tableName, attributeMap, relationships);
     }
 
     entities.push({

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -67,6 +67,42 @@ describe('erd extractor', () => {
     )).to.equal(true);
   });
 
+  it('extracts table-level SQL constraints into key flags and relationships', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-table-constraints') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+
+    const users = extracted.model.entities.find((entity) => entity.name === 'USERS');
+    expect(users).to.exist;
+    const userId = users.attributes.find((attribute) => attribute.name === 'id');
+    const email = users.attributes.find((attribute) => attribute.name === 'email');
+    expect(userId.keyFlags).to.include('PK');
+    expect(email.keyFlags).to.include('UK');
+
+    const sessions = extracted.model.entities.find((entity) => entity.name === 'SESSIONS');
+    expect(sessions).to.exist;
+    const userIdFk = sessions.attributes.find((attribute) => attribute.name === 'user_id');
+    expect(userIdFk.keyFlags).to.include('FK');
+
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'SESSIONS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+  });
+
+  it('parses sequential SQL CREATE TABLE blocks without semicolons', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-no-semicolon') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['COMMENTS', 'USERS']);
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'COMMENTS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+  });
+
   it('marks sources with no extractable entities as failed_parse', () => {
     const extracted = extractErdModel({ rootPath: fixturePath('sql-no-table') });
 

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -43,4 +43,35 @@ describe('erd extractor', () => {
     expect(extracted.model.entities).to.have.length(0);
     expect(extracted.diagnostics[0]).to.include('no supported schema sources found');
   });
+
+  it('infers relationships from *_id fields when explicit FK constraints are absent', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('inferred-heavy') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'COMMENTS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'inferred'
+    )).to.equal(true);
+  });
+
+  it('supports schema-qualified SQL table names and references', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-schema-qualified') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['SESSIONS', 'USERS']);
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'SESSIONS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+  });
+
+  it('marks sources with no extractable entities as failed_parse', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-no-table') });
+
+    expect(extracted.terminalClass).to.equal('failed_parse');
+    expect(extracted.model.entities).to.have.length(0);
+    expect(extracted.diagnostics[0]).to.include('schema sources found but no ERD entities extracted');
+  });
 });

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -6,6 +6,14 @@ function fixturePath(name) {
   return path.join(__dirname, 'fixtures', 'erd', name);
 }
 
+function hasRelationship(extracted, fromEntity, toEntity, provenance = 'explicit') {
+  return extracted.model.relationships.some((relationship) =>
+    relationship.fromEntity === fromEntity
+    && relationship.toEntity === toEntity
+    && relationship.provenance === provenance
+  );
+}
+
 describe('erd extractor', () => {
   it('extracts explicit Prisma entities, keys, and relationships', () => {
     const extracted = extractErdModel({ rootPath: fixturePath('explicit-schema') });
@@ -24,16 +32,8 @@ describe('erd extractor', () => {
     const email = user.attributes.find((attribute) => attribute.name === 'email');
     expect(email.keyFlags).to.include('UK');
 
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'TICKET'
-      && relationship.toEntity === 'USER'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'USER'
-      && relationship.toEntity === 'TICKET'
-      && relationship.provenance === 'explicit'
-    )).to.equal(false);
+    expect(hasRelationship(extracted, 'TICKET', 'USER')).to.equal(true);
+    expect(hasRelationship(extracted, 'USER', 'TICKET')).to.equal(false);
   });
 
   it('marks missing schema sources with failed_no_schema', () => {
@@ -48,11 +48,7 @@ describe('erd extractor', () => {
     const extracted = extractErdModel({ rootPath: fixturePath('inferred-heavy') });
 
     expect(extracted.terminalClass).to.equal('completed');
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'COMMENTS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'inferred'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'COMMENTS', 'USERS', 'inferred')).to.equal(true);
   });
 
   it('supports schema-qualified SQL table names and references', () => {
@@ -60,11 +56,7 @@ describe('erd extractor', () => {
 
     expect(extracted.terminalClass).to.equal('completed');
     expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['SESSIONS', 'USERS']);
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'SESSIONS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'SESSIONS', 'USERS')).to.equal(true);
   });
 
   it('extracts table-level SQL constraints into key flags and relationships', () => {
@@ -84,11 +76,7 @@ describe('erd extractor', () => {
     const userIdFk = sessions.attributes.find((attribute) => attribute.name === 'user_id');
     expect(userIdFk.keyFlags).to.include('FK');
 
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'SESSIONS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'SESSIONS', 'USERS')).to.equal(true);
   });
 
   it('parses sequential SQL CREATE TABLE blocks without semicolons', () => {
@@ -96,11 +84,7 @@ describe('erd extractor', () => {
 
     expect(extracted.terminalClass).to.equal('completed');
     expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['COMMENTS', 'USERS']);
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'COMMENTS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'COMMENTS', 'USERS')).to.equal(true);
   });
 
   it('marks sources with no extractable entities as failed_parse', () => {

--- a/test/fixtures/erd/inferred-heavy/sql/001_init.sql
+++ b/test/fixtures/erd/inferred-heavy/sql/001_init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE users (
+  id INT PRIMARY KEY
+);
+
+CREATE TABLE tickets (
+  id INT PRIMARY KEY,
+  user_id INT
+);
+
+CREATE TABLE comments (
+  id INT PRIMARY KEY,
+  user_id INT,
+  ticket_id INT
+);

--- a/test/fixtures/erd/sql-no-semicolon/sql/001_init.sql
+++ b/test/fixtures/erd/sql-no-semicolon/sql/001_init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+  id INT PRIMARY KEY
+)
+CREATE TABLE comments (
+  id INT PRIMARY KEY,
+  user_id INT REFERENCES users(id)
+)

--- a/test/fixtures/erd/sql-no-table/sql/001_init.sql
+++ b/test/fixtures/erd/sql-no-table/sql/001_init.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_email ON users(email);

--- a/test/fixtures/erd/sql-schema-qualified/sql/001_init.sql
+++ b/test/fixtures/erd/sql-schema-qualified/sql/001_init.sql
@@ -1,0 +1,8 @@
+CREATE TABLE auth.users (
+  id INT PRIMARY KEY
+);
+
+CREATE TABLE auth.sessions (
+  id INT PRIMARY KEY,
+  user_id INT REFERENCES auth.users(id)
+);

--- a/test/fixtures/erd/sql-table-constraints/sql/001_init.sql
+++ b/test/fixtures/erd/sql-table-constraints/sql/001_init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE users (
+  id INT,
+  email TEXT,
+  CONSTRAINT users_pk PRIMARY KEY (id),
+  UNIQUE (email)
+);
+
+CREATE TABLE sessions (
+  id INT PRIMARY KEY,
+  user_id INT,
+  CONSTRAINT sessions_user_fk FOREIGN KEY (user_id) REFERENCES users(id)
+);


### PR DESCRIPTION
# Pull request checklist

## Summary

- What changed (brief): Extended ERD extraction to include SQL files with schema-qualified `CREATE TABLE`/`REFERENCES` support, FK-name inference fallback, and parser failure classification tests/fixtures.
- Why this change was needed: Slice 3 adds SQL schema onboarding value while keeping the stacked rollout within diff-budget/risk policy.
- Risk and rollback plan: Low-to-medium. Focused extractor/test updates; rollback by reverting commit `72c6507`.

## Checklist

- [x] I did not push directly to `main`; this PR is from a dedicated branch.
- [x] Branch name follows policy (`codex/*` for agent-created branches).
- [ ] **(Pending)** Required local gates run: `npm test`, `npm run test:deep`, `npm run harness:check`.
- [ ] **(Pending)** Greptile review completed and findings handled (or explicitly waived).
- [ ] **(Pending)** Greptile review was performed by an independent reviewer (not the coding agent).
- [ ] **(Pending)** Greptile confidence score is `>= 4/5` for merge eligibility.
- [ ] **(Pending)** Codex review completed and findings handled (or explicitly waived).
- [x] Merge is blocked until all required checks pass.
- [x] I will delete branch/worktree after merge.

## Testing

- verification_commands: `npm test`; `npm run test:deep`; `npm run harness:check`
- verification_outcomes: `npm test` pass; `npm run test:deep` pass; `npm run harness:check` fail (memory-gate closeout flag requirement)
- blocked_steps_reason: local `harness:check` remains blocked by `FORJAMIE.md update flag not set in closeout` memory-gate policy
- Command: `npm test` -> pass
- Command: `npm run test:deep` -> pass
- Command: `npm run harness:check` -> fail (memory-gate closeout flag)
- Any other command(s): none

## Review artifacts

- Greptile: pending
- Greptile confidence score: pending
- Independent reviewer evidence: pending
- Codex: pending
- Additional evidence (if any): n/a

## Notes

Stacked PR: base branch is `codex/erd-slice-2-extractor-prisma` (PR #59). Merge #58 and #59 first, then retarget this PR to `main` if needed.
