### PR TITLE
feat: add ERD extractor foundations (slices 1-3)

### DIFF
--- a/docs/agents/06-contradictions-and-cleanup.md
+++ b/docs/agents/06-contradictions-and-cleanup.md
@@ -5,7 +5,7 @@
 - [Cleanup policy](#cleanup-policy)
 
 ## Resolved contradictions
-- Home-level AGENTS text references `/Users/jamiecraik/dev/config/codex` as a repo-specific preflight path.
+- Home-level AGENTS text references `/Users/jamiecraik/dev/configs/codex` as a repo-specific preflight path.
 - For this repository scope, the nearest-repo guidance applies and uses `/Users/jamiecraik/dev/diagram-cli` as the working root.
 - Node runtime expectations vary by source. Package metadata requires `node >=18`, while workflows currently include Node 20, 24, and 25 lanes.
 

--- a/scripts/check-environment.sh
+++ b/scripts/check-environment.sh
@@ -13,7 +13,7 @@ CONTRACT_PATH="$REPO_ROOT/harness.contract.json"
 	MAKEFILE_PATH="$REPO_ROOT/Makefile"
 	PREK_CONFIG_PATH="$REPO_ROOT/prek.toml"
 	PACKAGE_JSON_PATH="$REPO_ROOT/package.json"
-	TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-$HOME/dev/config/codex/instructions/tooling.md}"
+	TOOLING_DOC_PATH="${TOOLING_DOC_PATH:-$HOME/dev/configs/codex/instructions/tooling.md}"
 
 if [[ ! -f "$CONTRACT_PATH" ]]; then
 	echo "Error: missing contract file at $CONTRACT_PATH"

--- a/src/schema/erd-confidence.js
+++ b/src/schema/erd-confidence.js
@@ -1,0 +1,56 @@
+function roundTo(value, precision = 3) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function evaluateErdConfidence(model) {
+  const entities = Array.isArray(model?.entities) ? model.entities : [];
+  const relationships = Array.isArray(model?.relationships) ? model.relationships : [];
+
+  const entityCount = entities.length;
+  const explicitEntityCount = entities.filter((entity) => entity.source === 'explicit').length;
+  const relationshipCount = relationships.length;
+  const inferredRelationshipCount = relationships.filter(
+    (relationship) => relationship.provenance === 'inferred'
+  ).length;
+  const explicitRelationshipCount = relationships.filter(
+    (relationship) => relationship.provenance === 'explicit'
+  ).length;
+
+  const inferenceShare = relationshipCount > 0
+    ? inferredRelationshipCount / relationshipCount
+    : 0;
+
+  let outcome = 'publishable';
+  if (
+    entityCount === 0
+    || explicitEntityCount === 0
+    || (relationshipCount > 0 && inferenceShare > 0.8)
+  ) {
+    outcome = 'fail_confidence';
+  } else if (
+    relationshipCount > 0
+    && inferenceShare > 0.5
+    && inferenceShare <= 0.8
+  ) {
+    outcome = 'publishable_with_marker';
+  }
+
+  return {
+    outcome,
+    shouldFail: outcome === 'fail_confidence',
+    markerRequired: outcome === 'publishable_with_marker',
+    counts: {
+      entityCount,
+      explicitEntityCount,
+      relationshipCount,
+      explicitRelationshipCount,
+      inferredRelationshipCount,
+      inferenceShare: roundTo(inferenceShare, 4),
+    },
+  };
+}
+
+module.exports = {
+  evaluateErdConfidence,
+};

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -5,9 +5,18 @@ const { canonicalEntityName, normalizeErdModel } = require('./erd-model');
 
 const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'];
 const SOURCE_PRECEDENCE = Object.freeze(['prisma', 'sql']);
+const SOURCE_FILE_PATTERNS = Object.freeze({
+  prisma: '**/schema.prisma',
+  sql: '**/*.sql',
+});
 const PRISMA_SCALAR_TYPES = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes']);
 const SQL_IDENTIFIER_SOURCE = '(?:["`][^"`]+["`]|[A-Za-z_][A-Za-z0-9_]*)';
 const SQL_QUALIFIED_IDENTIFIER_SOURCE = `${SQL_IDENTIFIER_SOURCE}(?:\\s*\\.\\s*${SQL_IDENTIFIER_SOURCE})?`;
+const SQL_CREATE_TABLE_RE = new RegExp(
+  `\\bcreate\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?(${SQL_QUALIFIED_IDENTIFIER_SOURCE})\\s*\\(([\\s\\S]*?)\\)\\s*(?:;|(?=\\s*(?:create\\s+table\\b|$)))`,
+  'gi'
+);
+const SQL_INLINE_REFERENCES_RE = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -128,14 +137,10 @@ function tableNameFromSql(token) {
 function parseSqlSchema(fileContent) {
   const entities = [];
   const relationships = [];
-  const createTableRe = new RegExp(
-    `\\bcreate\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?(${SQL_QUALIFIED_IDENTIFIER_SOURCE})\\s*\\(([\\s\\S]*?)\\)\\s*(?:;|(?=\\s*(?:create\\s+table\\b|$)))`,
-    'gi'
-  );
-  const inlineReferencesRe = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
   let tableMatch;
+  SQL_CREATE_TABLE_RE.lastIndex = 0;
 
-  while ((tableMatch = createTableRe.exec(fileContent)) !== null) {
+  while ((tableMatch = SQL_CREATE_TABLE_RE.exec(fileContent)) !== null) {
     const tableName = tableNameFromSql(tableMatch[1]);
     const body = tableMatch[2];
     const definitions = splitSqlDefinitions(body);
@@ -146,7 +151,7 @@ function parseSqlSchema(fileContent) {
       if (!line) continue;
 
       if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
-        const fkConstraint = line.match(inlineReferencesRe);
+        const fkConstraint = line.match(SQL_INLINE_REFERENCES_RE);
         if (fkConstraint) {
           relationships.push({
             fromEntity: tableName,
@@ -169,7 +174,7 @@ function parseSqlSchema(fileContent) {
       if (/\bprimary\s+key\b/i.test(remainder)) keyFlags.push('PK');
       if (/\bunique\b/i.test(remainder)) keyFlags.push('UK');
 
-      const referencesMatch = remainder.match(inlineReferencesRe);
+      const referencesMatch = remainder.match(SQL_INLINE_REFERENCES_RE);
       if (referencesMatch) {
         keyFlags.push('FK');
         relationships.push({
@@ -196,6 +201,17 @@ function parseSqlSchema(fileContent) {
   }
 
   return { entities, relationships };
+}
+
+function parseSchemaSource(source, content) {
+  if (source === 'prisma') return parsePrismaSchema(content);
+  if (source === 'sql') return parseSqlSchema(content);
+  throw new Error(`unsupported schema source: ${source}`);
+}
+
+function appendParseDiagnostics(diagnostics, parseErrors) {
+  if (parseErrors.length === 0) return;
+  diagnostics.push(...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`));
 }
 
 function inferRelationshipsFromForeignKeyNames(entities, explicitRelationships) {
@@ -255,19 +271,17 @@ function extractErdModel({ rootPath }) {
     return result;
   }
 
-  const prismaFiles = globSync('**/schema.prisma', {
-    cwd: rootPath,
-    absolute: true,
-    ignore: DEFAULT_IGNORE,
-    nodir: true,
-  }).sort();
-  const sqlFiles = globSync('**/*.sql', {
-    cwd: rootPath,
-    absolute: true,
-    ignore: DEFAULT_IGNORE,
-    nodir: true,
-  }).sort();
-  const sourceCandidates = { prisma: prismaFiles, sql: sqlFiles };
+  const sourceCandidates = Object.fromEntries(
+    SOURCE_PRECEDENCE.map((source) => [
+      source,
+      globSync(SOURCE_FILE_PATTERNS[source], {
+        cwd: rootPath,
+        absolute: true,
+        ignore: DEFAULT_IGNORE,
+        nodir: true,
+      }).sort(),
+    ])
+  );
 
   const entities = [];
   const relationships = [];
@@ -278,7 +292,7 @@ function extractErdModel({ rootPath }) {
     for (const filePath of files) {
       try {
         const content = fs.readFileSync(filePath, 'utf8');
-        const parsed = source === 'prisma' ? parsePrismaSchema(content) : parseSqlSchema(content);
+        const parsed = parseSchemaSource(source, content);
         entities.push(...parsed.entities);
         relationships.push(...parsed.relationships);
         result.sourceFiles.push(path.relative(rootPath, filePath));
@@ -315,21 +329,14 @@ function extractErdModel({ rootPath }) {
     result.diagnostics.push('no supported schema sources found (expected schema.prisma or .sql files)');
   } else if (model.entities.length === 0) {
     result.terminalClass = 'failed_parse';
-    if (parseErrors.length > 0) {
-      result.diagnostics.push(
-        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
-      );
-    } else {
+    if (parseErrors.length === 0) {
       result.diagnostics.push(
         'schema sources found but no ERD entities extracted (check supported model shapes)'
       );
     }
+    appendParseDiagnostics(result.diagnostics, parseErrors);
   } else {
-    if (parseErrors.length > 0) {
-      result.diagnostics.push(
-        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
-      );
-    }
+    appendParseDiagnostics(result.diagnostics, parseErrors);
     result.terminalClass = 'completed';
   }
 

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -23,6 +23,7 @@ const SQL_TABLE_FOREIGN_KEY_RE = new RegExp(
   `^(?:constraint\\s+\\S+\\s+)?foreign\\s+key\\s*\\(([^)]+)\\)\\s+references\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`,
   'i'
 );
+const SQL_TABLE_CONSTRAINT_LINE_RE = /^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i;
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -157,6 +158,17 @@ function addSqlKeyFlags(attributeMap, columns, flag) {
   }
 }
 
+function pushExplicitSqlRelationship(relationships, fromEntity, toEntityToken) {
+  const toEntity = tableNameFromSql(toEntityToken);
+  if (!toEntity) return;
+  relationships.push({
+    fromEntity,
+    toEntity,
+    cardinality: '}o--||',
+    provenance: 'explicit',
+  });
+}
+
 function applyTableConstraint(line, tableName, attributeMap, relationships) {
   const primaryMatch = line.match(SQL_TABLE_PRIMARY_KEY_RE);
   if (primaryMatch) {
@@ -174,12 +186,7 @@ function applyTableConstraint(line, tableName, attributeMap, relationships) {
   if (!foreignKeyMatch) return;
 
   addSqlKeyFlags(attributeMap, parseSqlIdentifierList(foreignKeyMatch[1]), 'FK');
-  relationships.push({
-    fromEntity: tableName,
-    toEntity: tableNameFromSql(foreignKeyMatch[2]),
-    cardinality: '}o--||',
-    provenance: 'explicit',
-  });
+  pushExplicitSqlRelationship(relationships, tableName, foreignKeyMatch[2]);
 }
 
 function parseSqlSchema(fileContent) {
@@ -199,7 +206,7 @@ function parseSqlSchema(fileContent) {
       const line = definition.trim();
       if (!line) continue;
 
-      if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
+      if (SQL_TABLE_CONSTRAINT_LINE_RE.test(line)) {
         tableConstraints.push(line);
         continue;
       }
@@ -218,12 +225,7 @@ function parseSqlSchema(fileContent) {
       const referencesMatch = remainder.match(SQL_INLINE_REFERENCES_RE);
       if (referencesMatch) {
         keyFlags.push('FK');
-        relationships.push({
-          fromEntity: tableName,
-          toEntity: tableNameFromSql(referencesMatch[1]),
-          cardinality: '}o--||',
-          provenance: 'explicit',
-        });
+        pushExplicitSqlRelationship(relationships, tableName, referencesMatch[1]);
       }
 
       attributes.push({
@@ -234,11 +236,13 @@ function parseSqlSchema(fileContent) {
       });
     }
 
-    const attributeMap = new Map(
-      attributes.map((attribute) => [String(attribute.name).toLowerCase(), attribute])
-    );
-    for (const constraintLine of tableConstraints) {
-      applyTableConstraint(constraintLine, tableName, attributeMap, relationships);
+    if (tableConstraints.length > 0) {
+      const attributeMap = new Map(
+        attributes.map((attribute) => [String(attribute.name).toLowerCase(), attribute])
+      );
+      for (const constraintLine of tableConstraints) {
+        applyTableConstraint(constraintLine, tableName, attributeMap, relationships);
+      }
     }
 
     entities.push({

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -4,8 +4,10 @@ const { globSync } = require('glob');
 const { canonicalEntityName, normalizeErdModel } = require('./erd-model');
 
 const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'];
-const SOURCE_PRECEDENCE = Object.freeze(['prisma']);
+const SOURCE_PRECEDENCE = Object.freeze(['prisma', 'sql']);
 const PRISMA_SCALAR_TYPES = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes']);
+const SQL_IDENTIFIER_SOURCE = '(?:["`][^"`]+["`]|[A-Za-z_][A-Za-z0-9_]*)';
+const SQL_QUALIFIED_IDENTIFIER_SOURCE = `${SQL_IDENTIFIER_SOURCE}(?:\\s*\\.\\s*${SQL_IDENTIFIER_SOURCE})?`;
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -98,6 +100,104 @@ function parsePrismaSchema(fileContent) {
   return { entities, relationships };
 }
 
+function splitSqlDefinitions(body) {
+  const chunks = [];
+  let cursor = '';
+  let depth = 0;
+  for (const char of body) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth = Math.max(0, depth - 1);
+    if (char === ',' && depth === 0) {
+      chunks.push(cursor.trim());
+      cursor = '';
+      continue;
+    }
+    cursor += char;
+  }
+  if (cursor.trim()) chunks.push(cursor.trim());
+  return chunks;
+}
+
+function tableNameFromSql(token) {
+  const normalized = String(token || '').trim().replace(/\s*\.\s*/g, '.');
+  if (!normalized) return '';
+  const base = normalized.split('.').pop() || normalized;
+  return base.replace(/^["`]/, '').replace(/["`]$/, '');
+}
+
+function parseSqlSchema(fileContent) {
+  const entities = [];
+  const relationships = [];
+  const createTableRe = new RegExp(
+    `\\bcreate\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?(${SQL_QUALIFIED_IDENTIFIER_SOURCE})\\s*\\(([\\s\\S]*?)\\)\\s*(?:;|(?=\\s*(?:create\\s+table\\b|$)))`,
+    'gi'
+  );
+  const inlineReferencesRe = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
+  let tableMatch;
+
+  while ((tableMatch = createTableRe.exec(fileContent)) !== null) {
+    const tableName = tableNameFromSql(tableMatch[1]);
+    const body = tableMatch[2];
+    const definitions = splitSqlDefinitions(body);
+    const attributes = [];
+
+    for (const definition of definitions) {
+      const line = definition.trim();
+      if (!line) continue;
+
+      if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
+        const fkConstraint = line.match(inlineReferencesRe);
+        if (fkConstraint) {
+          relationships.push({
+            fromEntity: tableName,
+            toEntity: tableNameFromSql(fkConstraint[1]),
+            cardinality: '}o--||',
+            provenance: 'explicit',
+          });
+        }
+        continue;
+      }
+
+      const columnMatch = line.match(/^([`"]?[A-Za-z_][A-Za-z0-9_]*[`"]?)\s+([A-Za-z0-9_()]+)([\s\S]*)$/);
+      if (!columnMatch) continue;
+      const columnName = tableNameFromSql(columnMatch[1]);
+      const columnType = columnMatch[2];
+      const remainder = columnMatch[3] || '';
+      const remainderLower = remainder.toLowerCase();
+      const keyFlags = [];
+
+      if (/\bprimary\s+key\b/i.test(remainder)) keyFlags.push('PK');
+      if (/\bunique\b/i.test(remainder)) keyFlags.push('UK');
+
+      const referencesMatch = remainder.match(inlineReferencesRe);
+      if (referencesMatch) {
+        keyFlags.push('FK');
+        relationships.push({
+          fromEntity: tableName,
+          toEntity: tableNameFromSql(referencesMatch[1]),
+          cardinality: '}o--||',
+          provenance: 'explicit',
+        });
+      }
+
+      attributes.push({
+        name: columnName,
+        type: columnType.toLowerCase(),
+        nullable: !/\bnot\s+null\b/.test(remainderLower),
+        keyFlags,
+      });
+    }
+
+    entities.push({
+      name: tableName,
+      source: 'explicit',
+      attributes,
+    });
+  }
+
+  return { entities, relationships };
+}
+
 function inferRelationshipsFromForeignKeyNames(entities, explicitRelationships) {
   const byEntity = new Map(entities.map((entity) => [canonicalEntityName(entity.name), entity]));
   const explicitKeys = new Set(
@@ -161,24 +261,34 @@ function extractErdModel({ rootPath }) {
     ignore: DEFAULT_IGNORE,
     nodir: true,
   }).sort();
+  const sqlFiles = globSync('**/*.sql', {
+    cwd: rootPath,
+    absolute: true,
+    ignore: DEFAULT_IGNORE,
+    nodir: true,
+  }).sort();
+  const sourceCandidates = { prisma: prismaFiles, sql: sqlFiles };
 
   const entities = [];
   const relationships = [];
   const parseErrors = [];
 
-  for (const filePath of prismaFiles) {
-    try {
-      const content = fs.readFileSync(filePath, 'utf8');
-      const parsed = parsePrismaSchema(content);
-      entities.push(...parsed.entities);
-      relationships.push(...parsed.relationships);
-      result.sourceFiles.push(path.relative(rootPath, filePath));
-    } catch (error) {
-      parseErrors.push({
-        source: 'prisma',
-        file: path.relative(rootPath, filePath),
-        message: error.message,
-      });
+  for (const source of SOURCE_PRECEDENCE) {
+    const files = sourceCandidates[source] || [];
+    for (const filePath of files) {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const parsed = source === 'prisma' ? parsePrismaSchema(content) : parseSqlSchema(content);
+        entities.push(...parsed.entities);
+        relationships.push(...parsed.relationships);
+        result.sourceFiles.push(path.relative(rootPath, filePath));
+      } catch (error) {
+        parseErrors.push({
+          source,
+          file: path.relative(rootPath, filePath),
+          message: error.message,
+        });
+      }
     }
   }
 
@@ -202,7 +312,7 @@ function extractErdModel({ rootPath }) {
 
   if (result.sourceFiles.length === 0 && parseErrors.length === 0) {
     result.terminalClass = 'failed_no_schema';
-    result.diagnostics.push('no supported schema sources found (expected schema.prisma files)');
+    result.diagnostics.push('no supported schema sources found (expected schema.prisma or .sql files)');
   } else if (model.entities.length === 0) {
     result.terminalClass = 'failed_parse';
     if (parseErrors.length > 0) {

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -17,6 +17,12 @@ const SQL_CREATE_TABLE_RE = new RegExp(
   'gi'
 );
 const SQL_INLINE_REFERENCES_RE = new RegExp(`\\breferences\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`, 'i');
+const SQL_TABLE_PRIMARY_KEY_RE = /^(?:constraint\s+\S+\s+)?primary\s+key\s*\(([^)]+)\)/i;
+const SQL_TABLE_UNIQUE_RE = /^(?:constraint\s+\S+\s+)?unique\s*\(([^)]+)\)/i;
+const SQL_TABLE_FOREIGN_KEY_RE = new RegExp(
+  `^(?:constraint\\s+\\S+\\s+)?foreign\\s+key\\s*\\(([^)]+)\\)\\s+references\\s+(${SQL_QUALIFIED_IDENTIFIER_SOURCE})`,
+  'i'
+);
 
 function parsePrismaField(line) {
   const trimmed = line.trim();
@@ -134,6 +140,48 @@ function tableNameFromSql(token) {
   return base.replace(/^["`]/, '').replace(/["`]$/, '');
 }
 
+function parseSqlIdentifierList(tokenList) {
+  return String(tokenList || '')
+    .split(',')
+    .map((token) => tableNameFromSql(token))
+    .filter(Boolean);
+}
+
+function addSqlKeyFlags(attributeMap, columns, flag) {
+  for (const column of columns) {
+    const attribute = attributeMap.get(String(column).toLowerCase());
+    if (!attribute) continue;
+    if (!attribute.keyFlags.includes(flag)) {
+      attribute.keyFlags.push(flag);
+    }
+  }
+}
+
+function applyTableConstraint(line, tableName, attributeMap, relationships) {
+  const primaryMatch = line.match(SQL_TABLE_PRIMARY_KEY_RE);
+  if (primaryMatch) {
+    addSqlKeyFlags(attributeMap, parseSqlIdentifierList(primaryMatch[1]), 'PK');
+    return;
+  }
+
+  const uniqueMatch = line.match(SQL_TABLE_UNIQUE_RE);
+  if (uniqueMatch) {
+    addSqlKeyFlags(attributeMap, parseSqlIdentifierList(uniqueMatch[1]), 'UK');
+    return;
+  }
+
+  const foreignKeyMatch = line.match(SQL_TABLE_FOREIGN_KEY_RE);
+  if (!foreignKeyMatch) return;
+
+  addSqlKeyFlags(attributeMap, parseSqlIdentifierList(foreignKeyMatch[1]), 'FK');
+  relationships.push({
+    fromEntity: tableName,
+    toEntity: tableNameFromSql(foreignKeyMatch[2]),
+    cardinality: '}o--||',
+    provenance: 'explicit',
+  });
+}
+
 function parseSqlSchema(fileContent) {
   const entities = [];
   const relationships = [];
@@ -145,21 +193,14 @@ function parseSqlSchema(fileContent) {
     const body = tableMatch[2];
     const definitions = splitSqlDefinitions(body);
     const attributes = [];
+    const tableConstraints = [];
 
     for (const definition of definitions) {
       const line = definition.trim();
       if (!line) continue;
 
       if (/^(?:constraint|foreign\s+key|primary\s+key|unique)\b/i.test(line)) {
-        const fkConstraint = line.match(SQL_INLINE_REFERENCES_RE);
-        if (fkConstraint) {
-          relationships.push({
-            fromEntity: tableName,
-            toEntity: tableNameFromSql(fkConstraint[1]),
-            cardinality: '}o--||',
-            provenance: 'explicit',
-          });
-        }
+        tableConstraints.push(line);
         continue;
       }
 
@@ -191,6 +232,13 @@ function parseSqlSchema(fileContent) {
         nullable: !/\bnot\s+null\b/.test(remainderLower),
         keyFlags,
       });
+    }
+
+    const attributeMap = new Map(
+      attributes.map((attribute) => [String(attribute.name).toLowerCase(), attribute])
+    );
+    for (const constraintLine of tableConstraints) {
+      applyTableConstraint(constraintLine, tableName, attributeMap, relationships);
     }
 
     entities.push({

--- a/src/schema/erd-extractor.js
+++ b/src/schema/erd-extractor.js
@@ -1,0 +1,233 @@
+const fs = require('fs');
+const path = require('path');
+const { globSync } = require('glob');
+const { canonicalEntityName, normalizeErdModel } = require('./erd-model');
+
+const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'];
+const SOURCE_PRECEDENCE = Object.freeze(['prisma']);
+const PRISMA_SCALAR_TYPES = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes']);
+
+function parsePrismaField(line) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('@@')) return null;
+  const parts = trimmed.split(/\s+/);
+  if (parts.length < 2) return null;
+
+  const name = parts[0];
+  const rawType = parts[1];
+  const rest = parts.slice(2).join(' ');
+  const isArray = rawType.endsWith('[]');
+  const nullable = rawType.endsWith('?');
+  const baseType = rawType.replace(/\?$/, '').replace(/\[\]$/, '');
+  const keyFlags = [];
+
+  if (/\@id\b/.test(rest)) keyFlags.push('PK');
+  if (/\@unique\b/.test(rest)) keyFlags.push('UK');
+
+  const relationMatch = rest.match(/\@relation\s*\(([\s\S]*?)\)/);
+  const relationMeta = relationMatch ? relationMatch[1] : '';
+  const fieldListMatch = relationMeta.match(/fields\s*:\s*\[([^\]]+)\]/i);
+  const relationFields = fieldListMatch
+    ? fieldListMatch[1]
+      .split(',')
+      .map((field) => field.trim())
+      .filter(Boolean)
+    : [];
+
+  const isRelationType = /^[A-Z]/.test(baseType) && !PRISMA_SCALAR_TYPES.has(baseType);
+
+  return {
+    name,
+    type: baseType,
+    nullable,
+    isArray,
+    isRelationType,
+    relationFields,
+    keyFlags,
+  };
+}
+
+function parsePrismaSchema(fileContent) {
+  const entities = [];
+  const relationships = [];
+  const modelRe = /\bmodel\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{([\s\S]*?)\}/g;
+  let match;
+
+  while ((match = modelRe.exec(fileContent)) !== null) {
+    const modelName = match[1];
+    const body = match[2];
+    const fields = body.split(/\r?\n/).map(parsePrismaField).filter(Boolean);
+    const attributes = fields
+      .filter((field) => !field.isRelationType)
+      .map((field) => ({
+        name: field.name,
+        type: field.type,
+        nullable: field.nullable,
+        keyFlags: [...field.keyFlags],
+      }));
+    const attributesByName = new Map(attributes.map((attribute) => [attribute.name, attribute]));
+
+    for (const field of fields) {
+      for (const relationField of field.relationFields) {
+        const attribute = attributesByName.get(relationField);
+        if (attribute && !attribute.keyFlags.includes('FK')) {
+          attribute.keyFlags.push('FK');
+        }
+      }
+    }
+
+    entities.push({
+      name: modelName,
+      source: 'explicit',
+      attributes,
+    });
+
+    for (const field of fields) {
+      if (!field.isRelationType) continue;
+      if ((field.relationFields || []).length === 0) continue;
+      const cardinality = field.isArray ? '||--o{' : '}o--||';
+      relationships.push({
+        fromEntity: modelName,
+        toEntity: field.type,
+        cardinality,
+        provenance: 'explicit',
+      });
+    }
+  }
+
+  return { entities, relationships };
+}
+
+function inferRelationshipsFromForeignKeyNames(entities, explicitRelationships) {
+  const byEntity = new Map(entities.map((entity) => [canonicalEntityName(entity.name), entity]));
+  const explicitKeys = new Set(
+    explicitRelationships.map((relationship) => {
+      const from = canonicalEntityName(relationship.fromEntity);
+      const to = canonicalEntityName(relationship.toEntity);
+      return `${from}|${to}`;
+    })
+  );
+
+  const inferred = [];
+  for (const entity of entities) {
+    const from = canonicalEntityName(entity.name);
+    for (const attribute of entity.attributes || []) {
+      const attributeName = String(attribute.name || '');
+      if (!/(?:_id|Id)$/.test(attributeName)) continue;
+      const rawBase = attributeName.replace(/(?:_id|Id)$/, '');
+      if (!rawBase) continue;
+      const candidates = [
+        canonicalEntityName(rawBase),
+        canonicalEntityName(`${rawBase}s`),
+        canonicalEntityName(rawBase.endsWith('s') ? rawBase.slice(0, -1) : rawBase),
+      ].filter(Boolean);
+
+      const target = candidates.find((candidate) => byEntity.has(candidate));
+      if (!target) continue;
+      const key = `${from}|${target}`;
+      if (explicitKeys.has(key)) continue;
+      explicitKeys.add(key);
+      inferred.push({
+        fromEntity: from,
+        toEntity: target,
+        cardinality: '}o--||',
+        provenance: 'inferred',
+      });
+    }
+  }
+
+  return inferred;
+}
+
+function extractErdModel({ rootPath }) {
+  const result = {
+    extractionInvoked: true,
+    sourcePrecedence: [...SOURCE_PRECEDENCE],
+    sourceFiles: [],
+    diagnostics: [],
+    terminalClass: 'completed',
+    model: normalizeErdModel({ entities: [], relationships: [] }),
+  };
+
+  if (!rootPath || !fs.existsSync(rootPath)) {
+    result.terminalClass = 'failed_parse';
+    result.diagnostics.push('root path is missing or does not exist');
+    return result;
+  }
+
+  const prismaFiles = globSync('**/schema.prisma', {
+    cwd: rootPath,
+    absolute: true,
+    ignore: DEFAULT_IGNORE,
+    nodir: true,
+  }).sort();
+
+  const entities = [];
+  const relationships = [];
+  const parseErrors = [];
+
+  for (const filePath of prismaFiles) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const parsed = parsePrismaSchema(content);
+      entities.push(...parsed.entities);
+      relationships.push(...parsed.relationships);
+      result.sourceFiles.push(path.relative(rootPath, filePath));
+    } catch (error) {
+      parseErrors.push({
+        source: 'prisma',
+        file: path.relative(rootPath, filePath),
+        message: error.message,
+      });
+    }
+  }
+
+  const normalized = normalizeErdModel({
+    entities,
+    relationships,
+    sourceFiles: result.sourceFiles,
+    diagnostics: [],
+    sourcePrecedence: SOURCE_PRECEDENCE,
+  });
+
+  const inferredRelationships = inferRelationshipsFromForeignKeyNames(
+    normalized.entities,
+    normalized.relationships
+  );
+  const model = normalizeErdModel({
+    ...normalized,
+    relationships: [...normalized.relationships, ...inferredRelationships],
+    sourcePrecedence: SOURCE_PRECEDENCE,
+  });
+
+  if (result.sourceFiles.length === 0 && parseErrors.length === 0) {
+    result.terminalClass = 'failed_no_schema';
+    result.diagnostics.push('no supported schema sources found (expected schema.prisma files)');
+  } else if (model.entities.length === 0) {
+    result.terminalClass = 'failed_parse';
+    if (parseErrors.length > 0) {
+      result.diagnostics.push(
+        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
+      );
+    } else {
+      result.diagnostics.push(
+        'schema sources found but no ERD entities extracted (check supported model shapes)'
+      );
+    }
+  } else {
+    if (parseErrors.length > 0) {
+      result.diagnostics.push(
+        ...parseErrors.map((error) => `${error.source}:${error.file}: ${error.message}`)
+      );
+    }
+    result.terminalClass = 'completed';
+  }
+
+  result.model = model;
+  return result;
+}
+
+module.exports = {
+  SOURCE_PRECEDENCE,
+  extractErdModel,
+};

--- a/src/schema/erd-model.js
+++ b/src/schema/erd-model.js
@@ -1,0 +1,176 @@
+function sanitizeToken(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[`"'\\]/g, '')
+    .replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+function canonicalEntityName(value) {
+  const token = sanitizeToken(value);
+  return token ? token.toUpperCase() : '';
+}
+
+function canonicalAttributeName(value) {
+  return sanitizeToken(value);
+}
+
+function canonicalType(value) {
+  const token = sanitizeToken(value);
+  return token || 'unknown';
+}
+
+function toKeyFlags(flags) {
+  const order = ['PK', 'FK', 'UK'];
+  const seen = new Set((Array.isArray(flags) ? flags : []).map((flag) => String(flag).toUpperCase()));
+  return order.filter((flag) => seen.has(flag));
+}
+
+function mergeAttributes(existingAttributes, incomingAttributes) {
+  const byName = new Map();
+
+  for (const attribute of [...existingAttributes, ...incomingAttributes]) {
+    const name = canonicalAttributeName(attribute?.name);
+    if (!name) continue;
+    const prev = byName.get(name);
+    const next = {
+      name,
+      type: canonicalType(attribute?.type),
+      nullable: Boolean(attribute?.nullable),
+      keyFlags: toKeyFlags(attribute?.keyFlags),
+    };
+
+    if (!prev) {
+      byName.set(name, next);
+      continue;
+    }
+
+    const mergedFlags = toKeyFlags([...(prev.keyFlags || []), ...(next.keyFlags || [])]);
+    byName.set(name, {
+      name,
+      type: prev.type !== 'unknown' ? prev.type : next.type,
+      nullable: prev.nullable || next.nullable,
+      keyFlags: mergedFlags,
+    });
+  }
+
+  const keyPriority = ['PK', 'FK', 'UK'];
+  const score = (attribute) => {
+    if ((attribute.keyFlags || []).length === 0) return keyPriority.length;
+    const positions = attribute.keyFlags
+      .map((flag) => keyPriority.indexOf(flag))
+      .filter((index) => index >= 0);
+    return positions.length > 0 ? Math.min(...positions) : keyPriority.length;
+  };
+
+  return [...byName.values()].sort((a, b) => {
+    const scoreDiff = score(a) - score(b);
+    if (scoreDiff !== 0) return scoreDiff;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function normalizeErdModel(input) {
+  const entitiesInput = Array.isArray(input?.entities) ? input.entities : [];
+  const relationshipsInput = Array.isArray(input?.relationships) ? input.relationships : [];
+  const diagnostics = Array.isArray(input?.diagnostics) ? input.diagnostics : [];
+  const sourceFiles = Array.isArray(input?.sourceFiles) ? input.sourceFiles : [];
+  const sourcePrecedence = Array.isArray(input?.sourcePrecedence) ? input.sourcePrecedence : [];
+
+  const entitiesByName = new Map();
+  for (const entity of entitiesInput) {
+    const name = canonicalEntityName(entity?.name);
+    if (!name) continue;
+    const source = entity?.source === 'inferred' ? 'inferred' : 'explicit';
+    const existing = entitiesByName.get(name);
+    const attributes = mergeAttributes(existing?.attributes || [], entity?.attributes || []);
+    const merged = {
+      name,
+      source: existing?.source === 'explicit' || source === 'explicit' ? 'explicit' : 'inferred',
+      attributes,
+    };
+    entitiesByName.set(name, merged);
+  }
+
+  const entities = [...entitiesByName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const entitySet = new Set(entities.map((entity) => entity.name));
+  const relationshipMap = new Map();
+
+  for (const relationship of relationshipsInput) {
+    const fromEntity = canonicalEntityName(relationship?.fromEntity);
+    const toEntity = canonicalEntityName(relationship?.toEntity);
+    if (!fromEntity || !toEntity) continue;
+    if (!entitySet.has(fromEntity) || !entitySet.has(toEntity)) continue;
+
+    const provenance = relationship?.provenance === 'inferred' ? 'inferred' : 'explicit';
+    const cardinality = String(relationship?.cardinality || '||--o{');
+    const relationshipKey = `${fromEntity}|${toEntity}|${cardinality}`;
+    const existing = relationshipMap.get(relationshipKey);
+    if (!existing || existing.provenance === 'inferred') {
+      relationshipMap.set(relationshipKey, {
+        fromEntity,
+        toEntity,
+        cardinality,
+        provenance,
+      });
+    }
+  }
+
+  const relationships = [...relationshipMap.values()].sort((a, b) => {
+    if (a.fromEntity !== b.fromEntity) return a.fromEntity.localeCompare(b.fromEntity);
+    if (a.toEntity !== b.toEntity) return a.toEntity.localeCompare(b.toEntity);
+    if (a.provenance !== b.provenance) return a.provenance.localeCompare(b.provenance);
+    return a.cardinality.localeCompare(b.cardinality);
+  });
+
+  return {
+    entities,
+    relationships,
+    diagnostics,
+    sourceFiles: [...new Set(sourceFiles)].sort(),
+    sourcePrecedence: [...new Set(sourcePrecedence)],
+  };
+}
+
+function renderErdMermaid(model, options = {}) {
+  const entities = Array.isArray(model?.entities) ? model.entities : [];
+  const relationships = Array.isArray(model?.relationships) ? model.relationships : [];
+  const lines = ['erDiagram'];
+
+  if (options.lowConfidenceMarker) {
+    const percent = typeof options.inferenceShare === 'number'
+      ? Math.round(options.inferenceShare * 100)
+      : null;
+    const marker = percent === null
+      ? 'low-confidence: inferred relationships are above preferred threshold'
+      : `low-confidence: inferred relationships are ${percent}% of all relationships`;
+    lines.push(`  %% ${marker}`);
+  }
+
+  for (const entity of entities) {
+    lines.push(`  ${entity.name} {`);
+    for (const attribute of entity.attributes || []) {
+      const flags = (attribute.keyFlags || []).join(' ');
+      const suffix = flags ? ` ${flags}` : '';
+      lines.push(`    ${canonicalType(attribute.type)} ${canonicalAttributeName(attribute.name)}${suffix}`);
+    }
+    lines.push('  }');
+  }
+
+  if (relationships.length > 0) {
+    lines.push('');
+  }
+
+  for (const relationship of relationships) {
+    lines.push(
+      `  ${relationship.fromEntity} ${relationship.cardinality} ${relationship.toEntity} : ${relationship.provenance}`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  canonicalEntityName,
+  normalizeErdModel,
+  renderErdMermaid,
+};

--- a/test/erd-confidence.test.js
+++ b/test/erd-confidence.test.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const { evaluateErdConfidence } = require('../src/schema/erd-confidence');
+
+describe('erd confidence policy', () => {
+  it('classifies publishable when explicit entities exist and inference share is low', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('publishable');
+    expect(evaluated.shouldFail).to.equal(false);
+    expect(evaluated.counts.inferenceShare).to.equal(0);
+  });
+
+  it('classifies publishable_with_marker when inferred relationships dominate but stay <= 0.8', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [
+        { name: 'USER', source: 'explicit' },
+        { name: 'SESSION', source: 'explicit' },
+        { name: 'COMMENT', source: 'explicit' },
+      ],
+      relationships: [
+        { fromEntity: 'SESSION', toEntity: 'USER', provenance: 'explicit' },
+        { fromEntity: 'COMMENT', toEntity: 'USER', provenance: 'inferred' },
+        { fromEntity: 'COMMENT', toEntity: 'SESSION', provenance: 'inferred' },
+      ],
+    });
+
+    expect(evaluated.outcome).to.equal('publishable_with_marker');
+    expect(evaluated.markerRequired).to.equal(true);
+    expect(evaluated.counts.inferenceShare).to.equal(0.6667);
+  });
+
+  it('classifies fail_confidence when no explicit entities are available', () => {
+    const evaluated = evaluateErdConfidence({
+      entities: [],
+      relationships: [],
+    });
+
+    expect(evaluated.outcome).to.equal('fail_confidence');
+    expect(evaluated.shouldFail).to.equal(true);
+  });
+});

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -67,6 +67,42 @@ describe('erd extractor', () => {
     )).to.equal(true);
   });
 
+  it('extracts table-level SQL constraints into key flags and relationships', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-table-constraints') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+
+    const users = extracted.model.entities.find((entity) => entity.name === 'USERS');
+    expect(users).to.exist;
+    const userId = users.attributes.find((attribute) => attribute.name === 'id');
+    const email = users.attributes.find((attribute) => attribute.name === 'email');
+    expect(userId.keyFlags).to.include('PK');
+    expect(email.keyFlags).to.include('UK');
+
+    const sessions = extracted.model.entities.find((entity) => entity.name === 'SESSIONS');
+    expect(sessions).to.exist;
+    const userIdFk = sessions.attributes.find((attribute) => attribute.name === 'user_id');
+    expect(userIdFk.keyFlags).to.include('FK');
+
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'SESSIONS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+  });
+
+  it('parses sequential SQL CREATE TABLE blocks without semicolons', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-no-semicolon') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['COMMENTS', 'USERS']);
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'COMMENTS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+  });
+
   it('marks sources with no extractable entities as failed_parse', () => {
     const extracted = extractErdModel({ rootPath: fixturePath('sql-no-table') });
 

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -43,4 +43,35 @@ describe('erd extractor', () => {
     expect(extracted.model.entities).to.have.length(0);
     expect(extracted.diagnostics[0]).to.include('no supported schema sources found');
   });
+
+  it('infers relationships from *_id fields when explicit FK constraints are absent', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('inferred-heavy') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'COMMENTS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'inferred'
+    )).to.equal(true);
+  });
+
+  it('supports schema-qualified SQL table names and references', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-schema-qualified') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['SESSIONS', 'USERS']);
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'SESSIONS'
+      && relationship.toEntity === 'USERS'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+  });
+
+  it('marks sources with no extractable entities as failed_parse', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('sql-no-table') });
+
+    expect(extracted.terminalClass).to.equal('failed_parse');
+    expect(extracted.model.entities).to.have.length(0);
+    expect(extracted.diagnostics[0]).to.include('schema sources found but no ERD entities extracted');
+  });
 });

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -6,6 +6,14 @@ function fixturePath(name) {
   return path.join(__dirname, 'fixtures', 'erd', name);
 }
 
+function hasRelationship(extracted, fromEntity, toEntity, provenance = 'explicit') {
+  return extracted.model.relationships.some((relationship) =>
+    relationship.fromEntity === fromEntity
+    && relationship.toEntity === toEntity
+    && relationship.provenance === provenance
+  );
+}
+
 describe('erd extractor', () => {
   it('extracts explicit Prisma entities, keys, and relationships', () => {
     const extracted = extractErdModel({ rootPath: fixturePath('explicit-schema') });
@@ -24,16 +32,8 @@ describe('erd extractor', () => {
     const email = user.attributes.find((attribute) => attribute.name === 'email');
     expect(email.keyFlags).to.include('UK');
 
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'TICKET'
-      && relationship.toEntity === 'USER'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'USER'
-      && relationship.toEntity === 'TICKET'
-      && relationship.provenance === 'explicit'
-    )).to.equal(false);
+    expect(hasRelationship(extracted, 'TICKET', 'USER')).to.equal(true);
+    expect(hasRelationship(extracted, 'USER', 'TICKET')).to.equal(false);
   });
 
   it('marks missing schema sources with failed_no_schema', () => {
@@ -48,11 +48,7 @@ describe('erd extractor', () => {
     const extracted = extractErdModel({ rootPath: fixturePath('inferred-heavy') });
 
     expect(extracted.terminalClass).to.equal('completed');
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'COMMENTS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'inferred'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'COMMENTS', 'USERS', 'inferred')).to.equal(true);
   });
 
   it('supports schema-qualified SQL table names and references', () => {
@@ -60,11 +56,7 @@ describe('erd extractor', () => {
 
     expect(extracted.terminalClass).to.equal('completed');
     expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['SESSIONS', 'USERS']);
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'SESSIONS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'SESSIONS', 'USERS')).to.equal(true);
   });
 
   it('extracts table-level SQL constraints into key flags and relationships', () => {
@@ -84,11 +76,7 @@ describe('erd extractor', () => {
     const userIdFk = sessions.attributes.find((attribute) => attribute.name === 'user_id');
     expect(userIdFk.keyFlags).to.include('FK');
 
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'SESSIONS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'SESSIONS', 'USERS')).to.equal(true);
   });
 
   it('parses sequential SQL CREATE TABLE blocks without semicolons', () => {
@@ -96,11 +84,7 @@ describe('erd extractor', () => {
 
     expect(extracted.terminalClass).to.equal('completed');
     expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['COMMENTS', 'USERS']);
-    expect(extracted.model.relationships.some((relationship) =>
-      relationship.fromEntity === 'COMMENTS'
-      && relationship.toEntity === 'USERS'
-      && relationship.provenance === 'explicit'
-    )).to.equal(true);
+    expect(hasRelationship(extracted, 'COMMENTS', 'USERS')).to.equal(true);
   });
 
   it('marks sources with no extractable entities as failed_parse', () => {

--- a/test/erd-extractor.test.js
+++ b/test/erd-extractor.test.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const path = require('path');
+const { SOURCE_PRECEDENCE, extractErdModel } = require('../src/schema/erd-extractor');
+
+function fixturePath(name) {
+  return path.join(__dirname, 'fixtures', 'erd', name);
+}
+
+describe('erd extractor', () => {
+  it('extracts explicit Prisma entities, keys, and relationships', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('explicit-schema') });
+
+    expect(extracted.terminalClass).to.equal('completed');
+    expect(extracted.sourcePrecedence).to.deep.equal(SOURCE_PRECEDENCE);
+    expect(extracted.model.entities.map((entity) => entity.name)).to.deep.equal(['TICKET', 'USER']);
+
+    const ticket = extracted.model.entities.find((entity) => entity.name === 'TICKET');
+    expect(ticket).to.exist;
+    const authorId = ticket.attributes.find((attribute) => attribute.name === 'authorId');
+    expect(authorId).to.exist;
+    expect(authorId.keyFlags).to.include('FK');
+
+    const user = extracted.model.entities.find((entity) => entity.name === 'USER');
+    const email = user.attributes.find((attribute) => attribute.name === 'email');
+    expect(email.keyFlags).to.include('UK');
+
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'TICKET'
+      && relationship.toEntity === 'USER'
+      && relationship.provenance === 'explicit'
+    )).to.equal(true);
+    expect(extracted.model.relationships.some((relationship) =>
+      relationship.fromEntity === 'USER'
+      && relationship.toEntity === 'TICKET'
+      && relationship.provenance === 'explicit'
+    )).to.equal(false);
+  });
+
+  it('marks missing schema sources with failed_no_schema', () => {
+    const extracted = extractErdModel({ rootPath: fixturePath('no-schema') });
+
+    expect(extracted.terminalClass).to.equal('failed_no_schema');
+    expect(extracted.model.entities).to.have.length(0);
+    expect(extracted.diagnostics[0]).to.include('no supported schema sources found');
+  });
+});

--- a/test/fixtures/erd/explicit-schema/prisma/schema.prisma
+++ b/test/fixtures/erd/explicit-schema/prisma/schema.prisma
@@ -1,0 +1,12 @@
+model User {
+  id Int @id @default(autoincrement())
+  email String @unique
+  tickets Ticket[]
+}
+
+model Ticket {
+  id Int @id @default(autoincrement())
+  title String
+  authorId Int
+  author User @relation(fields: [authorId], references: [id])
+}

--- a/test/fixtures/erd/inferred-heavy/sql/001_init.sql
+++ b/test/fixtures/erd/inferred-heavy/sql/001_init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE users (
+  id INT PRIMARY KEY
+);
+
+CREATE TABLE tickets (
+  id INT PRIMARY KEY,
+  user_id INT
+);
+
+CREATE TABLE comments (
+  id INT PRIMARY KEY,
+  user_id INT,
+  ticket_id INT
+);

--- a/test/fixtures/erd/no-schema/src/index.js
+++ b/test/fixtures/erd/no-schema/src/index.js
@@ -1,0 +1,3 @@
+export function boot() {
+  return 'no schema here';
+}

--- a/test/fixtures/erd/sql-no-semicolon/sql/001_init.sql
+++ b/test/fixtures/erd/sql-no-semicolon/sql/001_init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+  id INT PRIMARY KEY
+)
+CREATE TABLE comments (
+  id INT PRIMARY KEY,
+  user_id INT REFERENCES users(id)
+)

--- a/test/fixtures/erd/sql-no-table/sql/001_init.sql
+++ b/test/fixtures/erd/sql-no-table/sql/001_init.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_email ON users(email);

--- a/test/fixtures/erd/sql-schema-qualified/sql/001_init.sql
+++ b/test/fixtures/erd/sql-schema-qualified/sql/001_init.sql
@@ -1,0 +1,8 @@
+CREATE TABLE auth.users (
+  id INT PRIMARY KEY
+);
+
+CREATE TABLE auth.sessions (
+  id INT PRIMARY KEY,
+  user_id INT REFERENCES auth.users(id)
+);

--- a/test/fixtures/erd/sql-table-constraints/sql/001_init.sql
+++ b/test/fixtures/erd/sql-table-constraints/sql/001_init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE users (
+  id INT,
+  email TEXT,
+  CONSTRAINT users_pk PRIMARY KEY (id),
+  UNIQUE (email)
+);
+
+CREATE TABLE sessions (
+  id INT PRIMARY KEY,
+  user_id INT,
+  CONSTRAINT sessions_user_fk FOREIGN KEY (user_id) REFERENCES users(id)
+);


### PR DESCRIPTION
# Pull request checklist

## Summary

- What changed (brief): Combines ERD slice work from model normalization/confidence through Prisma + SQL basics extraction into one mainline PR.
- Why this change was needed: Unblocks landing the ERD foundation while preserving strict confidence gating and extractor coverage.
- Risk and rollback plan: Medium. Additive schema/diagram generation behavior; rollback by reverting the merge commit.

## Checklist

- [x] I did not push directly to `main`; this PR is from a dedicated branch.
- [x] Branch name follows policy (`codex/*` for agent-created branches).
- [x] **(Complete)** Required local gates run: `npm test`, `npm run test:deep`.
- [ ] **(Pending)** Greptile review completed and findings handled (or explicitly waived).
- [ ] **(Pending)** Greptile review was performed by an independent reviewer (not the coding agent).
- [ ] **(Pending)** Greptile confidence score is `>= 4/5` for merge eligibility.
- [x] **(Complete)** Codex review completed and findings handled.
- [x] Merge is blocked until all required checks pass.
- [x] I will delete branch/worktree after merge.

## Testing

- verification_commands: `npm test`; `npm run test:deep`; `source scripts/codex-preflight.sh && preflight_repo`
- verification_outcomes: `npm test` pass; `npm run test:deep` pass; preflight pass
- blocked_steps_reason: n/a
- Command: `npm test` -> pass
- Command: `npm run test:deep` -> pass
- Command: `source scripts/codex-preflight.sh && preflight_repo` -> pass
- Any other command(s): `npm test -- test/erd-confidence.test.js` -> pass

## Review artifacts

- Greptile: pending
- Greptile confidence score: pending
- Independent reviewer evidence: pending
- Codex: completed (P1/P2/P3 findings resolved, regression tests added)
- Additional evidence (if any): CodeRabbit status checks green on stacked slice PRs (#59/#60)

## Notes

This PR supersedes stack merge ordering if lower-slice PR review state remains blocked by stale provider review decisions.