### PR TITLE
[codex] add agent artifact compaction and context refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This produces `pr-impact.html` and JSON artifacts for structured PR review narra
 ### AI-Focused Pipeline Outputs
 For AI agents (e.g., Cursor, GitHub Copilot), feeding `.mmd` files is far more efficient than loading the entire source tree into context. Run:
 ```bash
-diagram generate-all . --output-dir .diagram
+diagram generate-all . --output-dir .diagram --artifact-profile agent
 ```
 This produces minimal, highly textual context maps (e.g., Databases, User paths, Auth flows).
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,12 +81,14 @@ Generate all supported diagram types in one run.
 
 ```bash
 diagram generate-all .
-diagram generate-all . --output-dir ./docs/diagrams
+diagram generate-all . -O ./docs/diagrams
+diagram generate-all . -O ./.diagram --artifact-profile agent
 ```
 
 **Options:**
 
-- `-o, --output-dir <dir>` — output directory (default: `./diagrams`)
+- `-O, --output-dir <dir>` — output directory (default: `./diagrams`)
+- `--artifact-profile <profile>` — artifact profile: `full` (default, write all diagrams), `agent` (budgeted compact output), or `ultra-compact` (aggressive token budget)
 - `--analyzer <name>` — analyzer plugin (default: `default`)
 - `--emit-ir` — write typed IR artifact to `.diagram/ir/architecture-ir.json`
 - `--incremental` — use incremental cache at `.diagram/cache` when available

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ npm link
 ```bash
 diagram analyze .
 diagram generate .
-diagram all .
+diagram generate-all .
 ```
 
 Without linking:
@@ -42,14 +42,14 @@ Without linking:
 ```bash
 node src/diagram.js analyze .
 node src/diagram.js generate .
-node src/diagram.js all .
+node src/diagram.js generate-all .
 ```
 
 ## Verify your setup
 
 ```bash
 node src/diagram.js --help
-node src/diagram.js test --help
+node src/diagram.js validate --help
 npm test
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha",
     "test:watch": "mocha --watch",
     "test:deep": "node scripts/deep-regression.js",
-    "ci:artifacts": "mkdir -p .diagram && node src/diagram.js all . --output-dir .diagram && node src/diagram.js test . --format junit --output .diagram/architecture-results.xml",
+    "ci:artifacts": "mkdir -p .diagram && node src/diagram.js generate-all . --output-dir .diagram --artifact-profile agent && node src/diagram.js validate . --format junit --output .diagram/architecture-results.xml",
     "prepublishOnly": "npm test",
     "release:prepare": "bash scripts/release-npm.sh",
     "release:prepare:initial": "bash scripts/release-npm.sh --initial",

--- a/scripts/deep-regression.js
+++ b/scripts/deep-regression.js
@@ -162,6 +162,9 @@ function run() {
     'src/confidence/pipeline.js',
     'src/incremental/cache.js',
     'src/ir/architecture-ir.js',
+    'src/artifacts/artifact-budget.js',
+    'src/context/normalize-diagram-manifest.js',
+    'src/context/build-context-pack.js',
     'src/analyzers/default-analyzer.js',
     'src/analyzers/index.js',
   ];
@@ -255,6 +258,54 @@ function run() {
       `manifest should include ${type} diagram`
     );
   }
+  assert.strictEqual(manifest.compaction?.profile, 'full', 'default generate-all profile should be full');
+  assert.strictEqual(manifest.compaction?.applied, false, 'full profile should not compact artifacts');
+
+  const agentOutputDir = path.join(workspace, 'all-diagrams-agent');
+  const allAgentRun = runCLI([
+    'generate-all',
+    '.',
+    '-O',
+    agentOutputDir,
+    '--artifact-profile',
+    'agent'
+  ], workspace);
+  assert.strictEqual(allAgentRun.status, 0, `agent generate-all expected success, got ${allAgentRun.status}`);
+  const agentManifest = JSON.parse(fs.readFileSync(path.join(agentOutputDir, 'manifest.json'), 'utf8'));
+  assert.strictEqual(agentManifest.compaction?.profile, 'agent', 'agent profile should be recorded in manifest');
+  assert.ok(
+    Number.isInteger(agentManifest.compaction?.maxDiagrams),
+    'agent profile should expose maxDiagrams in manifest compaction metadata'
+  );
+  assert.ok(
+    agentManifest.diagrams.length <= agentManifest.compaction.maxDiagrams,
+    'agent profile should enforce maxDiagrams limit'
+  );
+  assert.ok(
+    Array.isArray(agentManifest.compaction?.omittedTypes) && agentManifest.compaction.omittedTypes.length > 0,
+    'agent profile should record omitted diagram types'
+  );
+
+  const ultraCompactOutputDir = path.join(workspace, 'all-diagrams-ultra-compact');
+  const ultraCompactRun = runCLI([
+    'generate-all',
+    '.',
+    '-O',
+    ultraCompactOutputDir,
+    '--artifact-profile',
+    'ultra-compact'
+  ], workspace);
+  assert.strictEqual(ultraCompactRun.status, 0, `ultra-compact generate-all expected success, got ${ultraCompactRun.status}`);
+  const ultraCompactManifest = JSON.parse(fs.readFileSync(path.join(ultraCompactOutputDir, 'manifest.json'), 'utf8'));
+  assert.strictEqual(
+    ultraCompactManifest.compaction?.profile,
+    'ultra-compact',
+    'ultra-compact profile should be recorded in manifest'
+  );
+  assert.ok(
+    ultraCompactManifest.diagrams.length <= ultraCompactManifest.compaction.maxDiagrams,
+    'ultra-compact profile should enforce stricter maxDiagrams limit'
+  );
 
 
   // Confidence pipeline capability checks should produce report artifact

--- a/scripts/refresh-diagram-context.sh
+++ b/scripts/refresh-diagram-context.sh
@@ -34,6 +34,9 @@ META_FILE="$CONTEXT_DIR/diagram-context.meta.json"
 LOG_FILE="$CONTEXT_DIR/refresh.log"
 MIN_SECONDS="${DIAGRAM_REFRESH_MIN_SECONDS:-1800}"
 MAX_FILES="${DIAGRAM_REFRESH_MAX_FILES:-1000}"
+CONTEXT_MAX_BYTES="${DIAGRAM_CONTEXT_MAX_BYTES:-12000}"
+CONTEXT_MAX_LINES_PER_DIAGRAM="${DIAGRAM_CONTEXT_MAX_LINES_PER_DIAGRAM:-140}"
+CONTEXT_MAX_EMBEDDED_DIAGRAMS="${DIAGRAM_CONTEXT_MAX_EMBEDDED_DIAGRAMS:-3}"
 NOW_EPOCH="$(date +%s)"
 
 mkdir -p "$DIAGRAM_DIR" "$CONTEXT_DIR"
@@ -62,8 +65,8 @@ if [[ "$FORCE" -ne 1 && -f "$META_FILE" ]]; then
 	fi
 fi
 
-if ! command -v diagram >/dev/null 2>&1; then
-	log "error: diagram CLI is not available"
+if ! command -v node >/dev/null 2>&1; then
+	log "error: node runtime is not available"
 	exit 1
 fi
 
@@ -74,10 +77,17 @@ EXCLUDE_PATTERNS="node_modules/**,.git/**,dist/**,${TMP_BASENAME}/**"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 pushd "$ROOT_DIR" >/dev/null
+GENERATE_ALL_CMD=(
+	node src/diagram.js generate-all .
+	--output-dir "$TMP_BASENAME/diagrams"
+	--artifact-profile agent
+	--exclude "$EXCLUDE_PATTERNS"
+	--max-files "$MAX_FILES"
+)
 if [[ "$QUIET" -eq 1 ]]; then
-	pnpm exec diagram all . --output-dir "$TMP_BASENAME/diagrams" --exclude "$EXCLUDE_PATTERNS" --max-files "$MAX_FILES" >/dev/null 2>&1
+	"${GENERATE_ALL_CMD[@]}" >/dev/null 2>&1
 else
-	pnpm exec diagram all . --output-dir "$TMP_BASENAME/diagrams" --exclude "$EXCLUDE_PATTERNS" --max-files "$MAX_FILES"
+	"${GENERATE_ALL_CMD[@]}"
 fi
 popd >/dev/null
 
@@ -87,222 +97,17 @@ if ! ls "$TMP_DIR/diagrams"/*.mmd >/dev/null 2>&1; then
 fi
 
 MANIFEST_PATH="$TMP_DIR/diagrams/manifest.json"
-ROOT_DIR="$ROOT_DIR" TMP_DIR="$TMP_DIR" MANIFEST_PATH="$MANIFEST_PATH" node <<'NODE'
-const { createHash } = require("node:crypto");
-const { readdirSync, readFileSync, writeFileSync } = require("node:fs");
-const { join } = require("node:path");
-
-const rootDir = process.env.ROOT_DIR;
-const tmpDir = process.env.TMP_DIR;
-const manifestPath = process.env.MANIFEST_PATH;
-
-if (!rootDir || !tmpDir || !manifestPath) {
-  throw new Error("diagram manifest generation requires ROOT_DIR, TMP_DIR, and MANIFEST_PATH");
-}
-
-const diagramsDir = join(tmpDir, "diagrams");
-const ensureTrailingNewline = (content) =>
-  content.endsWith("\n") ? content : `${content}\n`;
-const stableId = (prefix, value) => {
-  const slug = value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .slice(0, 48) || prefix;
-  const digest = createHash("sha1").update(value).digest("hex").slice(0, 8);
-  return `${prefix}_${slug}_${digest}`;
-};
-
-const parseArchitecture = (content) => {
-  const lines = content.trimEnd().split(/\r?\n/);
-  const subgraphs = [];
-  let currentSubgraph = null;
-
-  for (const line of lines) {
-    const subgraphMatch = line.match(/^  subgraph (\S+)\["(.+)"\]$/);
-    if (subgraphMatch) {
-      currentSubgraph = {
-        rawId: subgraphMatch[1],
-        label: subgraphMatch[2],
-        nodes: [],
-      };
-      subgraphs.push(currentSubgraph);
-      continue;
-    }
-
-    if (line === "  end") {
-      currentSubgraph = null;
-      continue;
-    }
-
-    const nodeMatch = line.match(/^    (\S+)\["(.+)"\]$/);
-    if (nodeMatch && currentSubgraph) {
-      currentSubgraph.nodes.push({
-        rawId: nodeMatch[1],
-        label: nodeMatch[2],
-      });
-    }
-  }
-
-  return subgraphs;
-};
-
-const buildArchitecture = (subgraphs) => {
-  const nodeMap = new Map();
-  const lines = ["graph TD"];
-  const sortedSubgraphs = [...subgraphs].sort((left, right) =>
-    left.label.localeCompare(right.label),
-  );
-
-  for (const subgraph of sortedSubgraphs) {
-    const subgraphId = stableId("sg", subgraph.label);
-    lines.push(`  subgraph ${subgraphId}["${subgraph.label}"]`);
-    const sortedNodes = [...subgraph.nodes].sort((left, right) =>
-      left.label.localeCompare(right.label),
-    );
-    for (const node of sortedNodes) {
-      const nodeId = stableId("node", `${subgraph.label}/${node.label}`);
-      nodeMap.set(node.rawId, { canonicalId: nodeId, label: node.label });
-      lines.push(`    ${nodeId}["${node.label}"]`);
-    }
-    lines.push("  end");
-  }
-
-  return {
-    content: ensureTrailingNewline(lines.join("\n")),
-    nodeMap,
-  };
-};
-
-const buildDependency = (content, nodeMap) => {
-  const lines = content.trimEnd().split(/\r?\n/);
-  if (lines.length === 0) {
-    return ensureTrailingNewline(content);
-  }
-
-  const externalNodeMap = new Map();
-  const dependencyEdges = [];
-  const styleEntries = [];
-
-  for (const line of lines.slice(1)) {
-    const edgeMatch = line.match(/^  (\S+)\["(.+)"\] --> (\S+)$/);
-    if (edgeMatch) {
-      const [, rawSourceId, sourceLabel, rawTargetId] = edgeMatch;
-      const target = nodeMap.get(rawTargetId) ?? {
-        canonicalId: stableId("node", rawTargetId),
-        label: rawTargetId,
-      };
-      const sourceCanonicalId =
-        externalNodeMap.get(rawSourceId) ?? stableId("ext", sourceLabel);
-      externalNodeMap.set(rawSourceId, sourceCanonicalId);
-      dependencyEdges.push({
-        line: `  ${sourceCanonicalId}["${sourceLabel}"] --> ${target.canonicalId}`,
-        sortKey: `${sourceLabel}::${target.label}`,
-      });
-      continue;
-    }
-
-    const styleMatch = line.match(/^  style (\S+) (.+)$/);
-    if (styleMatch) {
-      const [, rawNodeId, styleSpec] = styleMatch;
-      const canonicalId = externalNodeMap.get(rawNodeId);
-      if (canonicalId) {
-        styleEntries.push({
-          line: `  style ${canonicalId} ${styleSpec}`,
-          sortKey: canonicalId,
-        });
-      }
-    }
-  }
-
-  return ensureTrailingNewline(
-    [
-      "graph LR",
-      ...dependencyEdges
-        .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
-        .map((entry) => entry.line),
-      ...styleEntries
-        .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
-        .map((entry) => entry.line),
-    ].join("\n"),
-  );
-};
-
-const diagramFiles = readdirSync(diagramsDir).filter((entry) => entry.endsWith(".mmd"));
-const architecturePath = join(diagramsDir, "architecture.mmd");
-const dependencyPath = join(diagramsDir, "dependency.mmd");
-
-if (diagramFiles.includes("architecture.mmd")) {
-  const architectureContent = readFileSync(architecturePath, "utf8");
-  const { content: canonicalArchitecture, nodeMap } = buildArchitecture(
-    parseArchitecture(architectureContent),
-  );
-  writeFileSync(architecturePath, canonicalArchitecture);
-
-  if (diagramFiles.includes("dependency.mmd")) {
-    const dependencyContent = readFileSync(dependencyPath, "utf8");
-    writeFileSync(dependencyPath, buildDependency(dependencyContent, nodeMap));
-  }
-}
-
-for (const file of diagramFiles) {
-  if (file === "architecture.mmd" || file === "dependency.mmd") {
-    continue;
-  }
-  const filePath = join(diagramsDir, file);
-  writeFileSync(filePath, ensureTrailingNewline(readFileSync(filePath, "utf8").trimEnd()));
-}
-
-const diagrams = readdirSync(diagramsDir)
-  .filter((file) => file.endsWith(".mmd"))
-  .sort()
-	.map((file) => {
-		const content = readFileSync(join(diagramsDir, file), "utf8");
-		return {
-			type: file.replace(/\.mmd$/, ""),
-			file,
-			outputPath: `.diagram/${file}`,
-			lines: content.split(/\r?\n/).length,
-			bytes: Buffer.byteLength(content),
-			isPlaceholder:
-				/placeholder/i.test(content) ||
-				/not enough/i.test(content) ||
-				/limited to/i.test(content),
-		};
-	});
-
-writeFileSync(
-	manifestPath,
-	`${JSON.stringify(
-		{
-			generatedAt: new Date().toISOString(),
-			rootPath: rootDir,
-			diagramDir: ".diagram",
-			diagrams,
-		},
-		null,
-		2,
-	)}\n`,
-);
-NODE
+ROOT_DIR="$ROOT_DIR" TMP_DIR="$TMP_DIR" MANIFEST_PATH="$MANIFEST_PATH" \
+	node "$ROOT_DIR/src/context/normalize-diagram-manifest.js"
 
 TMP_CONTEXT="$TMP_DIR/diagram-context.md"
-{
-	echo "# Diagram Context Pack"
-	echo
-	echo "Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-	echo
-	for file in "$TMP_DIR"/diagrams/*.mmd; do
-		name="$(basename "$file" .mmd)"
-		echo "## ${name}"
-		echo
-		echo '```mermaid'
-		cat "$file"
-		echo
-		echo '```'
-		echo
-	done
-} > "$TMP_CONTEXT"
+ROOT_DIR="$ROOT_DIR" \
+TMP_DIR="$TMP_DIR" \
+CONTEXT_MAX_BYTES="$CONTEXT_MAX_BYTES" \
+CONTEXT_MAX_LINES_PER_DIAGRAM="$CONTEXT_MAX_LINES_PER_DIAGRAM" \
+CONTEXT_MAX_EMBEDDED_DIAGRAMS="$CONTEXT_MAX_EMBEDDED_DIAGRAMS" \
+CONTEXT_OUTPUT_PATH="$TMP_CONTEXT" \
+	node "$ROOT_DIR/src/context/build-context-pack.js"
 
 CONTEXT_SHA="$(shasum -a 256 "$TMP_CONTEXT" | awk '{print $1}')"
 GIT_HEAD="$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
@@ -327,6 +132,10 @@ jq --tab -n \
 	--arg git_head "$GIT_HEAD" \
 	--arg context_sha256 "$CONTEXT_SHA" \
 	--argjson diagram_count "$DIAGRAM_COUNT" \
+	--argjson context_max_bytes "$CONTEXT_MAX_BYTES" \
+	--argjson context_max_lines_per_diagram "$CONTEXT_MAX_LINES_PER_DIAGRAM" \
+	--argjson context_max_embedded_diagrams "$CONTEXT_MAX_EMBEDDED_DIAGRAMS" \
+	--argjson context_bytes "$(wc -c < "$TMP_CONTEXT" | tr -d ' ')" \
 	--argjson last_generated_epoch "$NOW_EPOCH" \
 	--argjson min_interval_seconds "$MIN_SECONDS" \
 	--arg changed "$CHANGED" \
@@ -335,6 +144,10 @@ jq --tab -n \
 		generated_at: $generated_at,
 		git_head: $git_head,
 		context_sha256: $context_sha256,
+		context_bytes: $context_bytes,
+		context_max_bytes: $context_max_bytes,
+		context_max_lines_per_diagram: $context_max_lines_per_diagram,
+		context_max_embedded_diagrams: $context_max_embedded_diagrams,
 		diagram_count: $diagram_count,
 		last_generated_epoch: $last_generated_epoch,
 		min_interval_seconds: $min_interval_seconds,

--- a/scripts/refresh-diagram-context.sh
+++ b/scripts/refresh-diagram-context.sh
@@ -101,12 +101,14 @@ ROOT_DIR="$ROOT_DIR" TMP_DIR="$TMP_DIR" MANIFEST_PATH="$MANIFEST_PATH" \
 	node "$ROOT_DIR/src/context/normalize-diagram-manifest.js"
 
 TMP_CONTEXT="$TMP_DIR/diagram-context.md"
+TMP_CONTEXT_META="$TMP_DIR/diagram-context.meta.json"
 ROOT_DIR="$ROOT_DIR" \
 TMP_DIR="$TMP_DIR" \
 CONTEXT_MAX_BYTES="$CONTEXT_MAX_BYTES" \
 CONTEXT_MAX_LINES_PER_DIAGRAM="$CONTEXT_MAX_LINES_PER_DIAGRAM" \
 CONTEXT_MAX_EMBEDDED_DIAGRAMS="$CONTEXT_MAX_EMBEDDED_DIAGRAMS" \
 CONTEXT_OUTPUT_PATH="$TMP_CONTEXT" \
+CONTEXT_META_OUTPUT_PATH="$TMP_CONTEXT_META" \
 	node "$ROOT_DIR/src/context/build-context-pack.js"
 
 CONTEXT_SHA="$(shasum -a 256 "$TMP_CONTEXT" | awk '{print $1}')"
@@ -139,9 +141,11 @@ jq --tab -n \
 	--argjson last_generated_epoch "$NOW_EPOCH" \
 	--argjson min_interval_seconds "$MIN_SECONDS" \
 	--arg changed "$CHANGED" \
+	--arg root_path "$ROOT_DIR" \
 	'{
 		schema_version: 1,
 		generated_at: $generated_at,
+		root_path: $root_path,
 		git_head: $git_head,
 		context_sha256: $context_sha256,
 		context_bytes: $context_bytes,

--- a/scripts/refresh-diagram-context.sh
+++ b/scripts/refresh-diagram-context.sh
@@ -27,6 +27,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "$ROOT_DIR/scripts/codex-preflight.sh"
+preflight_repo
+
 DIAGRAM_DIR="$ROOT_DIR/.diagram"
 CONTEXT_DIR="$DIAGRAM_DIR/context"
 CONTEXT_FILE="$CONTEXT_DIR/diagram-context.md"
@@ -85,10 +89,9 @@ GENERATE_ALL_CMD=(
 	--max-files "$MAX_FILES"
 )
 if [[ "$QUIET" -eq 1 ]]; then
-	"${GENERATE_ALL_CMD[@]}" >/dev/null 2>&1
-else
-	"${GENERATE_ALL_CMD[@]}"
+	GENERATE_ALL_CMD+=(--quiet)
 fi
+"${GENERATE_ALL_CMD[@]}"
 popd >/dev/null
 
 if ! ls "$TMP_DIR/diagrams"/*.mmd >/dev/null 2>&1; then
@@ -129,7 +132,12 @@ cp "$TMP_DIR"/diagrams/*.mmd "$DIAGRAM_DIR/"
 cp "$TMP_DIR/diagrams/manifest.json" "$DIAGRAM_DIR/manifest.json"
 cp "$TMP_CONTEXT" "$CONTEXT_FILE"
 
-jq --tab -n \
+if [[ ! -f "$TMP_CONTEXT_META" ]]; then
+	log "error: context pack metadata sidecar missing at $TMP_CONTEXT_META"
+	exit 1
+fi
+
+jq --tab \
 	--arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 	--arg git_head "$GIT_HEAD" \
 	--arg context_sha256 "$CONTEXT_SHA" \
@@ -142,20 +150,28 @@ jq --tab -n \
 	--argjson min_interval_seconds "$MIN_SECONDS" \
 	--arg changed "$CHANGED" \
 	--arg root_path "$ROOT_DIR" \
-	'{
-		schema_version: 1,
-		generated_at: $generated_at,
-		root_path: $root_path,
-		git_head: $git_head,
-		context_sha256: $context_sha256,
-		context_bytes: $context_bytes,
-		context_max_bytes: $context_max_bytes,
-		context_max_lines_per_diagram: $context_max_lines_per_diagram,
-		context_max_embedded_diagrams: $context_max_embedded_diagrams,
-		diagram_count: $diagram_count,
-		last_generated_epoch: $last_generated_epoch,
-		min_interval_seconds: $min_interval_seconds,
-		changed: ($changed == "true")
-	}' > "$META_FILE"
+	'
+		. as $packer
+		| ($packer // {})
+		| .schema_version = 1
+		| .generated_at = $generated_at
+		| .root_path = $root_path
+		| .git_head = $git_head
+		| .context_sha256 = $context_sha256
+		| .context_bytes = $context_bytes
+		| .context_max_bytes = $context_max_bytes
+		| .context_max_lines_per_diagram = $context_max_lines_per_diagram
+		| .context_max_embedded_diagrams = $context_max_embedded_diagrams
+		| .diagram_count = $diagram_count
+		| .last_generated_epoch = $last_generated_epoch
+		| .min_interval_seconds = $min_interval_seconds
+		| .changed = ($changed == "true")
+		| .context_path = ".diagram/context/diagram-context.md"
+		| .context_meta_path = ".diagram/context/diagram-context.meta.json"
+		| .diagram_manifest_path = ".diagram/manifest.json"
+		| .embedded_diagram_count = ((.embeddedCount // 0) | tonumber)
+		| .omitted_types = (.omittedTypes // [])
+		| .omitted_count = ((.omittedTypes // []) | length)
+	' "$TMP_CONTEXT_META" > "$META_FILE"
 
 log "ok: refreshed ${DIAGRAM_COUNT} diagrams (changed=${CHANGED})"

--- a/src/artifacts/artifact-budget.js
+++ b/src/artifacts/artifact-budget.js
@@ -1,0 +1,213 @@
+const AGENT_DIAGRAM_PRIORITY = Object.freeze([
+  'architecture',
+  'dependency',
+  'database',
+  'security',
+  'auth',
+  'events',
+  'user',
+  'flow',
+  'class',
+  'sequence',
+  'agent',
+  'c4context',
+  'rag',
+]);
+const BYTES_PER_TOKEN_ESTIMATE = 4;
+
+const BASE_ARTIFACT_PROFILES = Object.freeze({
+  full: Object.freeze({
+    name: 'full',
+    maxBytesTotal: null,
+    maxBytesPerDiagram: null,
+    maxDiagrams: null,
+    priorityOrder: AGENT_DIAGRAM_PRIORITY,
+  }),
+  agent: Object.freeze({
+    name: 'agent',
+    maxBytesTotal: 12000,
+    maxBytesPerDiagram: 4000,
+    maxDiagrams: 4,
+    priorityOrder: AGENT_DIAGRAM_PRIORITY,
+  }),
+  'ultra-compact': Object.freeze({
+    name: 'ultra-compact',
+    maxBytesTotal: 9000,
+    maxBytesPerDiagram: 3000,
+    maxDiagrams: 3,
+    priorityOrder: AGENT_DIAGRAM_PRIORITY,
+  }),
+});
+
+function toPositiveInt(value) {
+  if (value === null || value === undefined) return null;
+  if (value === '') return null;
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function byteLength(text) {
+  return Buffer.byteLength(String(text || ''), 'utf8');
+}
+
+function estimateTokensFromBytes(byteCount) {
+  const normalized = Number.isFinite(byteCount) ? byteCount : 0;
+  return Math.ceil(normalized / BYTES_PER_TOKEN_ESTIMATE);
+}
+
+function resolveArtifactProfile(profileName = 'full', overrides = {}) {
+  const normalizedName = String(profileName || 'full').toLowerCase();
+  const base = BASE_ARTIFACT_PROFILES[normalizedName];
+  if (!base) {
+    const supported = Object.keys(BASE_ARTIFACT_PROFILES).join(', ');
+    throw new Error(`Invalid artifact profile "${profileName}". Supported profiles: ${supported}`);
+  }
+
+  return {
+    ...base,
+    maxBytesTotal: toPositiveInt(overrides.maxBytesTotal) ?? base.maxBytesTotal,
+    maxBytesPerDiagram: toPositiveInt(overrides.maxBytesPerDiagram) ?? base.maxBytesPerDiagram,
+    maxDiagrams: toPositiveInt(overrides.maxDiagrams) ?? base.maxDiagrams,
+    priorityOrder: Array.isArray(base.priorityOrder) ? [...base.priorityOrder] : [],
+  };
+}
+
+function sortByPriority(diagrams, priorityOrder) {
+  const rank = new Map((priorityOrder || []).map((type, index) => [type, index]));
+  return [...(Array.isArray(diagrams) ? diagrams : [])].sort((left, right) => {
+    const leftRank = rank.has(left.type) ? rank.get(left.type) : Number.MAX_SAFE_INTEGER;
+    const rightRank = rank.has(right.type) ? rank.get(right.type) : Number.MAX_SAFE_INTEGER;
+    if (leftRank !== rightRank) {
+      return leftRank - rightRank;
+    }
+    return String(left.type || '').localeCompare(String(right.type || ''));
+  });
+}
+
+function truncateMermaidByBytes(mermaid, maxBytes) {
+  const content = String(mermaid || '');
+  const originalBytes = byteLength(content);
+  if (!maxBytes || originalBytes <= maxBytes) {
+    return {
+      content,
+      bytes: originalBytes,
+      originalBytes,
+      truncated: false,
+      omittedLines: 0,
+    };
+  }
+
+  const sourceLines = content.split(/\r?\n/);
+  const marker = `%% compacted: truncated to ${maxBytes} bytes from ${originalBytes} bytes`;
+  const suffix = '%% compacted: tail omitted';
+  const header = `${marker}\n`;
+  const footer = `\n${suffix}\n`;
+  const maxBodyBytes = maxBytes - byteLength(header) - byteLength(footer);
+  if (maxBodyBytes <= 0) {
+    const minimal = `${marker}\n${suffix}\n`;
+    return {
+      content: minimal,
+      bytes: byteLength(minimal),
+      originalBytes,
+      truncated: true,
+      omittedLines: sourceLines.length,
+    };
+  }
+
+  const keptLines = [];
+  let bodyBytes = 0;
+  for (const line of sourceLines) {
+    const candidate = keptLines.length > 0 ? `\n${line}` : line;
+    const candidateBytes = byteLength(candidate);
+    if (bodyBytes + candidateBytes > maxBodyBytes) {
+      break;
+    }
+    keptLines.push(line);
+    bodyBytes += candidateBytes;
+  }
+
+  const compacted = `${header}${keptLines.join('\n')}${footer}`;
+  return {
+    content: compacted,
+    bytes: byteLength(compacted),
+    originalBytes,
+    truncated: true,
+    omittedLines: Math.max(sourceLines.length - keptLines.length, 0),
+  };
+}
+
+function applyArtifactBudget(diagrams, profile) {
+  const sorted = sortByPriority(diagrams, profile.priorityOrder);
+  const included = [];
+  const omitted = [];
+  let writtenBytes = 0;
+  let originalBytes = 0;
+
+  for (const diagram of sorted) {
+    const source = String(diagram.mermaid || '');
+    const sourceBytes = byteLength(source);
+    originalBytes += sourceBytes;
+
+    if (profile.maxDiagrams && included.length >= profile.maxDiagrams) {
+      omitted.push({
+        type: diagram.type,
+        reason: 'max_diagrams',
+        originalBytes: sourceBytes,
+      });
+      continue;
+    }
+
+    const compacted = truncateMermaidByBytes(source, profile.maxBytesPerDiagram);
+
+    if (profile.maxBytesTotal && writtenBytes + compacted.bytes > profile.maxBytesTotal) {
+      omitted.push({
+        type: diagram.type,
+        reason: 'max_total_bytes',
+        originalBytes: sourceBytes,
+      });
+      continue;
+    }
+
+    included.push({
+      type: diagram.type,
+      mermaid: compacted.content,
+      bytes: compacted.bytes,
+      originalBytes: compacted.originalBytes,
+      truncated: compacted.truncated,
+      omittedLines: compacted.omittedLines,
+      bytesSaved: Math.max(compacted.originalBytes - compacted.bytes, 0),
+    });
+    writtenBytes += compacted.bytes;
+  }
+
+  const truncatedTypes = included
+    .filter((entry) => entry.truncated)
+    .map((entry) => entry.type);
+  const bytesSaved = Math.max(originalBytes - writtenBytes, 0);
+
+  return {
+    included,
+    omitted,
+    truncatedTypes,
+    applied: omitted.length > 0 || truncatedTypes.length > 0,
+    summary: {
+      generatedCount: sorted.length,
+      includedCount: included.length,
+      omittedCount: omitted.length,
+      originalBytes,
+      writtenBytes,
+      bytesSaved,
+    },
+  };
+}
+
+module.exports = {
+  AGENT_DIAGRAM_PRIORITY,
+  estimateTokensFromBytes,
+  resolveArtifactProfile,
+  applyArtifactBudget,
+  sortByPriority,
+};

--- a/src/context/build-context-pack.js
+++ b/src/context/build-context-pack.js
@@ -1,0 +1,169 @@
+const { readFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+const {
+  AGENT_DIAGRAM_PRIORITY,
+  estimateTokensFromBytes,
+  sortByPriority,
+} = require('../artifacts/artifact-budget');
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function trimToMaxLines(content, maxLines) {
+  const lines = String(content || '').trimEnd().split(/\r?\n/);
+  if (lines.length <= maxLines) {
+    return { text: lines.join('\n'), truncated: false, omittedLines: 0 };
+  }
+  const kept = lines.slice(0, maxLines);
+  return {
+    text: kept.join('\n'),
+    truncated: true,
+    omittedLines: lines.length - maxLines,
+  };
+}
+
+function buildContextPack({
+  rootDir,
+  tmpDir,
+  contextMaxBytes = 12000,
+  contextMaxLinesPerDiagram = 140,
+  contextMaxEmbeddedDiagrams = 3,
+  contextPath,
+}) {
+  if (!rootDir || !tmpDir || !contextPath) {
+    throw new Error('buildContextPack requires rootDir, tmpDir, and contextPath');
+  }
+
+  const diagramsDir = join(tmpDir, 'diagrams');
+  const manifestPath = join(diagramsDir, 'manifest.json');
+  const nowIso = new Date().toISOString();
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const diagramEntries = Array.isArray(manifest.diagrams) ? manifest.diagrams : [];
+  const sortedDiagrams = sortByPriority(diagramEntries, AGENT_DIAGRAM_PRIORITY);
+
+  const headerLines = [
+    '# Diagram Context Pack',
+    '',
+    'Machine-oriented context for agents. This pack is intentionally compact and token-budgeted.',
+    '',
+    `Generated: ${nowIso}`,
+    `Root: ${rootDir}`,
+    `Context byte budget: ${contextMaxBytes}`,
+    `Max embedded diagrams: ${contextMaxEmbeddedDiagrams}`,
+    `Max lines per embedded diagram: ${contextMaxLinesPerDiagram}`,
+    '',
+    '## Diagram Index',
+    '',
+    '| Type | File | Bytes | Lines | Placeholder | Approx Tokens |',
+    '| --- | --- | ---: | ---: | --- | ---: |',
+  ];
+
+  for (const entry of sortedDiagrams) {
+    headerLines.push(
+      `| ${entry.type} | ${entry.file} | ${entry.bytes} | ${entry.lines} | ${entry.isPlaceholder ? 'yes' : 'no'} | ${estimateTokensFromBytes(entry.bytes || 0)} |`
+    );
+  }
+
+  headerLines.push('');
+  headerLines.push('## Embedded Mermaid (Budgeted)');
+  headerLines.push('');
+
+  let contextText = `${headerLines.join('\n')}\n`;
+  let embeddedCount = 0;
+  const omittedTypes = [];
+
+  for (const entry of sortedDiagrams) {
+    if (embeddedCount >= contextMaxEmbeddedDiagrams) {
+      omittedTypes.push(entry.type);
+      continue;
+    }
+    const diagramPath = join(diagramsDir, entry.file);
+    const rawContent = readFileSync(diagramPath, 'utf8');
+    const rawBytes = Buffer.byteLength(rawContent || '', 'utf8');
+    const { text: trimmedContent, truncated, omittedLines } = trimToMaxLines(
+      rawContent,
+      contextMaxLinesPerDiagram
+    );
+
+    const section = [
+      `### ${entry.type}`,
+      '',
+      `Path: \`.diagram/${entry.file}\``,
+      `Approx tokens (full): ${estimateTokensFromBytes(rawBytes)}`,
+      ...(truncated ? [`Note: truncated to ${contextMaxLinesPerDiagram} lines (${omittedLines} lines omitted).`] : []),
+      '',
+      '```mermaid',
+      trimmedContent,
+      '```',
+      '',
+    ].join('\n');
+
+    const next = contextText + section;
+    if (Buffer.byteLength(next, 'utf8') > contextMaxBytes) {
+      omittedTypes.push(entry.type);
+      continue;
+    }
+    contextText = next;
+    embeddedCount += 1;
+  }
+
+  if (omittedTypes.length > 0) {
+    contextText += [
+      '## Omitted Diagrams',
+      '',
+      `Omitted from embedding due to budget/profile constraints: ${omittedTypes.join(', ')}`,
+      'Use `.diagram/*.mmd` files directly for full-fidelity diagram content.',
+      '',
+    ].join('\n');
+  }
+
+  writeFileSync(contextPath, contextText);
+  return {
+    embeddedCount,
+    omittedTypes,
+    bytes: Buffer.byteLength(contextText, 'utf8'),
+  };
+}
+
+function runFromEnv() {
+  const rootDir = process.env.ROOT_DIR;
+  const tmpDir = process.env.TMP_DIR;
+  const contextPath = process.env.CONTEXT_OUTPUT_PATH;
+  const contextMaxBytes = parsePositiveInt(process.env.CONTEXT_MAX_BYTES || '12000', 12000);
+  const contextMaxLinesPerDiagram = parsePositiveInt(
+    process.env.CONTEXT_MAX_LINES_PER_DIAGRAM || '140',
+    140
+  );
+  const contextMaxEmbeddedDiagrams = parsePositiveInt(
+    process.env.CONTEXT_MAX_EMBEDDED_DIAGRAMS || '3',
+    3
+  );
+
+  buildContextPack({
+    rootDir,
+    tmpDir,
+    contextPath,
+    contextMaxBytes,
+    contextMaxLinesPerDiagram,
+    contextMaxEmbeddedDiagrams,
+  });
+}
+
+if (require.main === module) {
+  try {
+    runFromEnv();
+  } catch (error) {
+    console.error(error.message || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  buildContextPack,
+};

--- a/src/context/build-context-pack.js
+++ b/src/context/build-context-pack.js
@@ -50,6 +50,77 @@ function buildOmittedSection(omittedTypes, compact = false) {
   ].join('\n');
 }
 
+function buildHeaderText({
+  sortedDiagrams,
+  contextMaxBytes,
+  contextMaxEmbeddedDiagrams,
+  contextMaxLinesPerDiagram,
+}) {
+  const staticPrefix = [
+    '# Diagram Context Pack',
+    '',
+    'Machine-oriented context for agents. This pack is intentionally compact and token-budgeted.',
+    '',
+    `Context byte budget: ${contextMaxBytes}`,
+    `Max embedded diagrams: ${contextMaxEmbeddedDiagrams}`,
+    `Max lines per embedded diagram: ${contextMaxLinesPerDiagram}`,
+    '',
+    '## Diagram Index',
+    '',
+    '| Type | File | Bytes | Lines | Placeholder | Approx Tokens |',
+    '| --- | --- | ---: | ---: | --- | ---: |',
+  ];
+  const staticSuffix = ['', '## Embedded Mermaid (Budgeted)', '', ''];
+  const indexRows = [];
+
+  const buildCandidate = (rows, summaryLine = '') => {
+    const summary = summaryLine ? ['', summaryLine] : [];
+    return `${staticPrefix.concat(rows, summary, staticSuffix).join('\n')}`;
+  };
+
+  for (const entry of sortedDiagrams) {
+    const row = `| ${entry.type} | ${entry.file} | ${entry.bytes} | ${entry.lines} | ${entry.isPlaceholder ? 'yes' : 'no'} | ${estimateTokensFromBytes(entry.bytes || 0)} |`;
+    const candidateWithRow = buildCandidate(indexRows.concat(row));
+    if (Buffer.byteLength(candidateWithRow, 'utf8') > contextMaxBytes) {
+      break;
+    }
+    indexRows.push(row);
+  }
+
+  const compacted = indexRows.length < sortedDiagrams.length;
+  const compactSummary = compacted
+    ? `Diagram index compacted to ${indexRows.length}/${sortedDiagrams.length} row(s) to fit budget.`
+    : '';
+  const candidate = buildCandidate(indexRows, compactSummary);
+  if (Buffer.byteLength(candidate, 'utf8') <= contextMaxBytes) {
+    return {
+      text: candidate,
+      indexRowsIncluded: indexRows.length,
+      headerCompacted: compacted,
+    };
+  }
+
+  const minimal = [
+    '# Diagram Context Pack',
+    '',
+    `Compact header due to strict budget (${contextMaxBytes} bytes).`,
+    `Diagrams available: ${sortedDiagrams.length}`,
+    `Max embedded diagrams: ${contextMaxEmbeddedDiagrams}`,
+    `Max lines per embedded diagram: ${contextMaxLinesPerDiagram}`,
+    '',
+    '## Embedded Mermaid (Budgeted)',
+    '',
+  ].join('\n');
+  if (Buffer.byteLength(minimal, 'utf8') > contextMaxBytes) {
+    throw new Error(`Context byte budget (${contextMaxBytes}) is too small for header.`);
+  }
+  return {
+    text: minimal,
+    indexRowsIncluded: 0,
+    headerCompacted: true,
+  };
+}
+
 function buildContextPack({
   rootDir,
   tmpDir,
@@ -71,32 +142,13 @@ function buildContextPack({
   const diagramEntries = Array.isArray(manifest.diagrams) ? manifest.diagrams : [];
   const sortedDiagrams = sortByPriority(diagramEntries, AGENT_DIAGRAM_PRIORITY);
 
-  const headerLines = [
-    '# Diagram Context Pack',
-    '',
-    'Machine-oriented context for agents. This pack is intentionally compact and token-budgeted.',
-    '',
-    `Context byte budget: ${contextMaxBytes}`,
-    `Max embedded diagrams: ${contextMaxEmbeddedDiagrams}`,
-    `Max lines per embedded diagram: ${contextMaxLinesPerDiagram}`,
-    '',
-    '## Diagram Index',
-    '',
-    '| Type | File | Bytes | Lines | Placeholder | Approx Tokens |',
-    '| --- | --- | ---: | ---: | --- | ---: |',
-  ];
-
-  for (const entry of sortedDiagrams) {
-    headerLines.push(
-      `| ${entry.type} | ${entry.file} | ${entry.bytes} | ${entry.lines} | ${entry.isPlaceholder ? 'yes' : 'no'} | ${estimateTokensFromBytes(entry.bytes || 0)} |`
-    );
-  }
-
-  headerLines.push('');
-  headerLines.push('## Embedded Mermaid (Budgeted)');
-  headerLines.push('');
-
-  const headerText = `${headerLines.join('\n')}\n`;
+  const header = buildHeaderText({
+    sortedDiagrams,
+    contextMaxBytes,
+    contextMaxEmbeddedDiagrams,
+    contextMaxLinesPerDiagram,
+  });
+  const headerText = header.text;
   let contextText = headerText;
   let embeddedCount = 0;
   const omittedTypes = [];
@@ -181,6 +233,8 @@ function buildContextPack({
     embeddedCount,
     omittedTypes,
     bytes: Buffer.byteLength(contextText, 'utf8'),
+    headerCompacted: header.headerCompacted,
+    indexRowsIncluded: header.indexRowsIncluded,
   };
   writeFileSync(contextPath, contextText);
   if (contextMetaPath) {

--- a/src/context/build-context-pack.js
+++ b/src/context/build-context-pack.js
@@ -27,6 +27,29 @@ function trimToMaxLines(content, maxLines) {
   };
 }
 
+function buildOmittedSection(omittedTypes, compact = false) {
+  if (!Array.isArray(omittedTypes) || omittedTypes.length === 0) {
+    return '';
+  }
+
+  if (compact) {
+    return [
+      '## Omitted Diagrams',
+      '',
+      `Omitted from embedding due to budget/profile constraints: ${omittedTypes.length} diagram(s).`,
+      '',
+    ].join('\n');
+  }
+
+  return [
+    '## Omitted Diagrams',
+    '',
+    `Omitted from embedding due to budget/profile constraints: ${omittedTypes.join(', ')}`,
+    'Use `.diagram/*.mmd` files directly for full-fidelity diagram content.',
+    '',
+  ].join('\n');
+}
+
 function buildContextPack({
   rootDir,
   tmpDir,
@@ -34,6 +57,7 @@ function buildContextPack({
   contextMaxLinesPerDiagram = 140,
   contextMaxEmbeddedDiagrams = 3,
   contextPath,
+  contextMetaPath,
 }) {
   if (!rootDir || !tmpDir || !contextPath) {
     throw new Error('buildContextPack requires rootDir, tmpDir, and contextPath');
@@ -52,8 +76,6 @@ function buildContextPack({
     '',
     'Machine-oriented context for agents. This pack is intentionally compact and token-budgeted.',
     '',
-    `Generated: ${nowIso}`,
-    `Root: ${rootDir}`,
     `Context byte budget: ${contextMaxBytes}`,
     `Max embedded diagrams: ${contextMaxEmbeddedDiagrams}`,
     `Max lines per embedded diagram: ${contextMaxLinesPerDiagram}`,
@@ -74,11 +96,14 @@ function buildContextPack({
   headerLines.push('## Embedded Mermaid (Budgeted)');
   headerLines.push('');
 
-  let contextText = `${headerLines.join('\n')}\n`;
+  const headerText = `${headerLines.join('\n')}\n`;
+  let contextText = headerText;
   let embeddedCount = 0;
   const omittedTypes = [];
+  const includedSections = [];
 
-  for (const entry of sortedDiagrams) {
+  for (let index = 0; index < sortedDiagrams.length; index += 1) {
+    const entry = sortedDiagrams[index];
     if (embeddedCount >= contextMaxEmbeddedDiagrams) {
       omittedTypes.push(entry.type);
       continue;
@@ -109,32 +134,66 @@ function buildContextPack({
       omittedTypes.push(entry.type);
       continue;
     }
+
+    const remainingTypes = sortedDiagrams
+      .slice(index + 1)
+      .map((remaining) => remaining.type);
+    const reservedOmittedSection = buildOmittedSection(
+      omittedTypes.concat(remainingTypes)
+    );
+    if (Buffer.byteLength(next + reservedOmittedSection, 'utf8') > contextMaxBytes) {
+      omittedTypes.push(entry.type);
+      continue;
+    }
+
     contextText = next;
     embeddedCount += 1;
+    includedSections.push({ type: entry.type, section });
   }
 
-  if (omittedTypes.length > 0) {
-    contextText += [
-      '## Omitted Diagrams',
-      '',
-      `Omitted from embedding due to budget/profile constraints: ${omittedTypes.join(', ')}`,
-      'Use `.diagram/*.mmd` files directly for full-fidelity diagram content.',
-      '',
-    ].join('\n');
+  let omittedSection = buildOmittedSection(omittedTypes);
+  while (
+    Buffer.byteLength(contextText + omittedSection, 'utf8') > contextMaxBytes
+    && includedSections.length > 0
+  ) {
+    const removed = includedSections.pop();
+    embeddedCount = Math.max(embeddedCount - 1, 0);
+    omittedTypes.push(removed.type);
+    contextText = headerText + includedSections.map((entry) => entry.section).join('');
+    omittedSection = buildOmittedSection(omittedTypes);
   }
 
-  writeFileSync(contextPath, contextText);
-  return {
+  if (
+    Buffer.byteLength(contextText + omittedSection, 'utf8') > contextMaxBytes
+    && omittedTypes.length > 0
+  ) {
+    omittedSection = buildOmittedSection(omittedTypes, true);
+  }
+
+  if (Buffer.byteLength(contextText + omittedSection, 'utf8') > contextMaxBytes) {
+    omittedSection = '';
+  }
+
+  contextText += omittedSection;
+  const result = {
+    generatedAt: nowIso,
+    rootPath: rootDir,
     embeddedCount,
     omittedTypes,
     bytes: Buffer.byteLength(contextText, 'utf8'),
   };
+  writeFileSync(contextPath, contextText);
+  if (contextMetaPath) {
+    writeFileSync(contextMetaPath, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  return result;
 }
 
 function runFromEnv() {
   const rootDir = process.env.ROOT_DIR;
   const tmpDir = process.env.TMP_DIR;
   const contextPath = process.env.CONTEXT_OUTPUT_PATH;
+  const contextMetaPath = process.env.CONTEXT_META_OUTPUT_PATH;
   const contextMaxBytes = parsePositiveInt(process.env.CONTEXT_MAX_BYTES || '12000', 12000);
   const contextMaxLinesPerDiagram = parsePositiveInt(
     process.env.CONTEXT_MAX_LINES_PER_DIAGRAM || '140',
@@ -149,6 +208,7 @@ function runFromEnv() {
     rootDir,
     tmpDir,
     contextPath,
+    contextMetaPath,
     contextMaxBytes,
     contextMaxLinesPerDiagram,
     contextMaxEmbeddedDiagrams,

--- a/src/context/normalize-diagram-manifest.js
+++ b/src/context/normalize-diagram-manifest.js
@@ -1,0 +1,222 @@
+const { createHash } = require('node:crypto');
+const { readdirSync, readFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+function ensureTrailingNewline(content) {
+  return content.endsWith('\n') ? content : `${content}\n`;
+}
+
+function stableId(prefix, value) {
+  const slug = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 48) || prefix;
+  const digest = createHash('sha1').update(String(value)).digest('hex').slice(0, 8);
+  return `${prefix}_${slug}_${digest}`;
+}
+
+function parseArchitecture(content) {
+  const lines = String(content || '').trimEnd().split(/\r?\n/);
+  const subgraphs = [];
+  let currentSubgraph = null;
+
+  for (const line of lines) {
+    const subgraphMatch = line.match(/^  subgraph (\S+)\["(.+)"\]$/);
+    if (subgraphMatch) {
+      currentSubgraph = {
+        rawId: subgraphMatch[1],
+        label: subgraphMatch[2],
+        nodes: [],
+      };
+      subgraphs.push(currentSubgraph);
+      continue;
+    }
+
+    if (line === '  end') {
+      currentSubgraph = null;
+      continue;
+    }
+
+    const nodeMatch = line.match(/^    (\S+)\["(.+)"\]$/);
+    if (nodeMatch && currentSubgraph) {
+      currentSubgraph.nodes.push({
+        rawId: nodeMatch[1],
+        label: nodeMatch[2],
+      });
+    }
+  }
+
+  return subgraphs;
+}
+
+function buildArchitecture(subgraphs) {
+  const nodeMap = new Map();
+  const lines = ['graph TD'];
+  const sortedSubgraphs = [...subgraphs].sort((left, right) =>
+    left.label.localeCompare(right.label)
+  );
+
+  for (const subgraph of sortedSubgraphs) {
+    const subgraphId = stableId('sg', subgraph.label);
+    lines.push(`  subgraph ${subgraphId}["${subgraph.label}"]`);
+    const sortedNodes = [...subgraph.nodes].sort((left, right) =>
+      left.label.localeCompare(right.label)
+    );
+    for (const node of sortedNodes) {
+      const nodeId = stableId('node', `${subgraph.label}/${node.label}`);
+      nodeMap.set(node.rawId, { canonicalId: nodeId, label: node.label });
+      lines.push(`    ${nodeId}["${node.label}"]`);
+    }
+    lines.push('  end');
+  }
+
+  return {
+    content: ensureTrailingNewline(lines.join('\n')),
+    nodeMap,
+  };
+}
+
+function buildDependency(content, nodeMap) {
+  const lines = String(content || '').trimEnd().split(/\r?\n/);
+  if (lines.length === 0) {
+    return ensureTrailingNewline(String(content || ''));
+  }
+
+  const externalNodeMap = new Map();
+  const dependencyEdges = [];
+  const styleEntries = [];
+
+  for (const line of lines.slice(1)) {
+    const edgeMatch = line.match(/^  (\S+)\["(.+)"\] --> (\S+)$/);
+    if (edgeMatch) {
+      const [, rawSourceId, sourceLabel, rawTargetId] = edgeMatch;
+      const target = nodeMap.get(rawTargetId) ?? {
+        canonicalId: stableId('node', rawTargetId),
+        label: rawTargetId,
+      };
+      const sourceCanonicalId =
+        externalNodeMap.get(rawSourceId) ?? stableId('ext', sourceLabel);
+      externalNodeMap.set(rawSourceId, sourceCanonicalId);
+      dependencyEdges.push({
+        line: `  ${sourceCanonicalId}["${sourceLabel}"] --> ${target.canonicalId}`,
+        sortKey: `${sourceLabel}::${target.label}`,
+      });
+      continue;
+    }
+
+    const styleMatch = line.match(/^  style (\S+) (.+)$/);
+    if (!styleMatch) continue;
+    const [, rawNodeId, styleSpec] = styleMatch;
+    const canonicalId = externalNodeMap.get(rawNodeId);
+    if (!canonicalId) continue;
+    styleEntries.push({
+      line: `  style ${canonicalId} ${styleSpec}`,
+      sortKey: canonicalId,
+    });
+  }
+
+  return ensureTrailingNewline([
+    'graph LR',
+    ...dependencyEdges
+      .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
+      .map((entry) => entry.line),
+    ...styleEntries
+      .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
+      .map((entry) => entry.line),
+  ].join('\n'));
+}
+
+function isPlaceholderDiagram(content) {
+  const text = String(content || '');
+  return /placeholder/i.test(text)
+    || /not enough/i.test(text)
+    || /limited to/i.test(text);
+}
+
+function normalizeDiagramManifest({ rootDir, tmpDir, manifestPath }) {
+  if (!rootDir || !tmpDir || !manifestPath) {
+    throw new Error('normalizeDiagramManifest requires rootDir, tmpDir, and manifestPath');
+  }
+
+  const diagramsDir = join(tmpDir, 'diagrams');
+  let sourceManifest = {};
+  try {
+    sourceManifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (_error) {
+    sourceManifest = {};
+  }
+
+  const diagramFiles = readdirSync(diagramsDir).filter((entry) => entry.endsWith('.mmd'));
+  const architecturePath = join(diagramsDir, 'architecture.mmd');
+  const dependencyPath = join(diagramsDir, 'dependency.mmd');
+
+  if (diagramFiles.includes('architecture.mmd')) {
+    const architectureContent = readFileSync(architecturePath, 'utf8');
+    const { content: canonicalArchitecture, nodeMap } = buildArchitecture(
+      parseArchitecture(architectureContent)
+    );
+    writeFileSync(architecturePath, canonicalArchitecture);
+
+    if (diagramFiles.includes('dependency.mmd')) {
+      const dependencyContent = readFileSync(dependencyPath, 'utf8');
+      writeFileSync(dependencyPath, buildDependency(dependencyContent, nodeMap));
+    }
+  }
+
+  for (const file of diagramFiles) {
+    if (file === 'architecture.mmd' || file === 'dependency.mmd') {
+      continue;
+    }
+    const filePath = join(diagramsDir, file);
+    writeFileSync(filePath, ensureTrailingNewline(readFileSync(filePath, 'utf8').trimEnd()));
+  }
+
+  const diagrams = readdirSync(diagramsDir)
+    .filter((file) => file.endsWith('.mmd'))
+    .sort()
+    .map((file) => {
+      const content = readFileSync(join(diagramsDir, file), 'utf8');
+      return {
+        type: file.replace(/\.mmd$/, ''),
+        file,
+        outputPath: `.diagram/${file}`,
+        lines: content.split(/\r?\n/).length,
+        bytes: Buffer.byteLength(content),
+        isPlaceholder: isPlaceholderDiagram(content),
+      };
+    });
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    rootPath: rootDir,
+    diagramDir: '.diagram',
+    ...(sourceManifest && typeof sourceManifest.compaction === 'object'
+      ? { compaction: sourceManifest.compaction }
+      : {}),
+    diagrams,
+  };
+
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function runFromEnv() {
+  const rootDir = process.env.ROOT_DIR;
+  const tmpDir = process.env.TMP_DIR;
+  const manifestPath = process.env.MANIFEST_PATH;
+  normalizeDiagramManifest({ rootDir, tmpDir, manifestPath });
+}
+
+if (require.main === module) {
+  try {
+    runFromEnv();
+  } catch (error) {
+    console.error(error.message || String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  normalizeDiagramManifest,
+};

--- a/src/context/normalize-diagram-manifest.js
+++ b/src/context/normalize-diagram-manifest.js
@@ -1,6 +1,7 @@
 const { createHash } = require('node:crypto');
 const { readdirSync, readFileSync, writeFileSync } = require('node:fs');
 const { join } = require('node:path');
+const { estimateTokensFromBytes } = require('../artifacts/artifact-budget');
 
 function ensureTrailingNewline(content) {
   return content.endsWith('\n') ? content : `${content}\n`;
@@ -134,6 +135,13 @@ function isPlaceholderDiagram(content) {
     || /limited to/i.test(text);
 }
 
+function parseNonNegativeInt(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  if (parsed < 0) return null;
+  return Math.floor(parsed);
+}
+
 function normalizeDiagramManifest({ rootDir, tmpDir, manifestPath }) {
   if (!rootDir || !tmpDir || !manifestPath) {
     throw new Error('normalizeDiagramManifest requires rootDir, tmpDir, and manifestPath');
@@ -153,9 +161,18 @@ function normalizeDiagramManifest({ rootDir, tmpDir, manifestPath }) {
 
   if (diagramFiles.includes('architecture.mmd')) {
     const architectureContent = readFileSync(architecturePath, 'utf8');
-    const { content: canonicalArchitecture, nodeMap } = buildArchitecture(
-      parseArchitecture(architectureContent)
+    const parsedArchitecture = parseArchitecture(architectureContent);
+    const hasParsedNodes = parsedArchitecture.some((subgraph) =>
+      Array.isArray(subgraph.nodes) && subgraph.nodes.length > 0
     );
+    if (!hasParsedNodes) {
+      throw new Error('Failed to normalize architecture.mmd: parsed structure was empty.');
+    }
+
+    const { content: canonicalArchitecture, nodeMap } = buildArchitecture(parsedArchitecture);
+    if (!(nodeMap instanceof Map) || nodeMap.size === 0) {
+      throw new Error('Failed to normalize architecture.mmd: canonical node map was empty.');
+    }
     writeFileSync(architecturePath, canonicalArchitecture);
 
     if (diagramFiles.includes('dependency.mmd')) {
@@ -172,17 +189,39 @@ function normalizeDiagramManifest({ rootDir, tmpDir, manifestPath }) {
     writeFileSync(filePath, ensureTrailingNewline(readFileSync(filePath, 'utf8').trimEnd()));
   }
 
+  const sourceDiagramEntries = Array.isArray(sourceManifest.diagrams)
+    ? sourceManifest.diagrams.filter((entry) => entry && typeof entry === 'object')
+    : [];
+  const sourceByFile = new Map();
+  const sourceByType = new Map();
+  for (const entry of sourceDiagramEntries) {
+    if (typeof entry.file === 'string' && entry.file) {
+      sourceByFile.set(entry.file, entry);
+    }
+    if (typeof entry.type === 'string' && entry.type) {
+      sourceByType.set(entry.type, entry);
+    }
+  }
+
   const diagrams = readdirSync(diagramsDir)
     .filter((file) => file.endsWith('.mmd'))
     .sort()
     .map((file) => {
       const content = readFileSync(join(diagramsDir, file), 'utf8');
+      const type = file.replace(/\.mmd$/, '');
+      const existingEntry = sourceByFile.get(file) || sourceByType.get(type) || {};
+      const bytes = Buffer.byteLength(content);
+      const sourceBytes = parseNonNegativeInt(existingEntry.sourceBytes) ?? bytes;
+      const tokenBaseBytes = sourceBytes > 0 ? sourceBytes : bytes;
       return {
-        type: file.replace(/\.mmd$/, ''),
+        ...existingEntry,
+        type,
         file,
         outputPath: `.diagram/${file}`,
         lines: content.split(/\r?\n/).length,
-        bytes: Buffer.byteLength(content),
+        bytes,
+        sourceBytes,
+        approxTokens: estimateTokensFromBytes(tokenBaseBytes),
         isPlaceholder: isPlaceholderDiagram(content),
       };
     });

--- a/src/context/normalize-diagram-manifest.js
+++ b/src/context/normalize-diagram-manifest.js
@@ -143,8 +143,8 @@ function normalizeDiagramManifest({ rootDir, tmpDir, manifestPath }) {
   let sourceManifest = {};
   try {
     sourceManifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  } catch (_error) {
-    sourceManifest = {};
+  } catch (error) {
+    throw new Error(`Failed to read diagram manifest at ${manifestPath}: ${error.message}`);
   }
 
   const diagramFiles = readdirSync(diagramsDir).filter((entry) => entry.endsWith('.mmd'));
@@ -188,7 +188,9 @@ function normalizeDiagramManifest({ rootDir, tmpDir, manifestPath }) {
     });
 
   const manifest = {
-    generatedAt: new Date().toISOString(),
+    ...(typeof sourceManifest.generatedAt === 'string' && sourceManifest.generatedAt
+      ? { generatedAt: sourceManifest.generatedAt }
+      : {}),
     rootPath: rootDir,
     diagramDir: '.diagram',
     ...(sourceManifest && typeof sourceManifest.compaction === 'object'

--- a/src/core/analysis-generation.js
+++ b/src/core/analysis-generation.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { glob } = require('glob');
 const chalk = require('chalk');
 const crypto = require('crypto');
+const { estimateTokensFromBytes } = require('../artifacts/artifact-budget');
 
 function detectLanguage(filePath) {
   if (typeof filePath !== 'string') return 'unknown';
@@ -1439,7 +1440,7 @@ function toManifestEntry(type, filePath, mermaidCode, rootPath) {
     outputPath: rootPath ? path.relative(rootPath, filePath) : filePath,
     lines: lines.length,
     bytes,
-    approxTokens: Math.ceil(bytes / 4),
+    approxTokens: estimateTokensFromBytes(bytes),
     isPlaceholder: isPlaceholderDiagram(mermaidCode),
   };
 }

--- a/src/core/analysis-generation.js
+++ b/src/core/analysis-generation.js
@@ -1432,12 +1432,14 @@ function isPlaceholderDiagram(mermaidCode) {
 
 function toManifestEntry(type, filePath, mermaidCode, rootPath) {
   const lines = typeof mermaidCode === 'string' ? mermaidCode.split('\n') : [];
+  const bytes = Buffer.byteLength(mermaidCode || '', 'utf8');
   return {
     type,
     file: path.basename(filePath),
     outputPath: rootPath ? path.relative(rootPath, filePath) : filePath,
     lines: lines.length,
-    bytes: Buffer.byteLength(mermaidCode || '', 'utf8'),
+    bytes,
+    approxTokens: Math.ceil(bytes / 4),
     isPlaceholder: isPlaceholderDiagram(mermaidCode),
   };
 }

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -28,6 +28,11 @@ const {
   toManifestEntry,
 } = require('./core/analysis-generation');
 const {
+  estimateTokensFromBytes,
+  resolveArtifactProfile,
+  applyArtifactBudget,
+} = require('./artifacts/artifact-budget');
+const {
   escapeHtml,
   groupChangePaths,
   buildRiskNarrative,
@@ -641,6 +646,7 @@ program
   .command('generate-all [path]')
   .description('Generate all diagram types')
   .option('-O, --output-dir <dir>', 'Output directory', './diagrams')
+  .option('--artifact-profile <profile>', 'Artifact output profile (full, agent, ultra-compact)', 'full')
   .option('-q, --quiet', 'Suppress non-essential logging', false)
   .option('-p, --patterns <list>', 'File patterns', '**/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.py,**/*.go,**/*.rs')
   .option('-e, --exclude <list>', 'Exclude patterns', 'node_modules/**,.git/**,dist/**')
@@ -652,10 +658,12 @@ program
   .action(async (targetPath, options) => {
     const root = resolveRootPathOrExit(targetPath);
     let outDir;
+    let artifactProfile;
     try {
       outDir = validateOutputPath(options.outputDir, root);
+      artifactProfile = resolveArtifactProfile(options.artifactProfile);
     } catch (err) {
-      console.error(chalk.red('❌ Output path error:'), err.message);
+      console.error(chalk.red('❌ Configuration error:'), err.message);
       process.exit(2);
     }
     
@@ -675,24 +683,68 @@ program
     if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
     
     const types = [...SUPPORTED_DIAGRAM_TYPES];
+    const generatedDiagrams = types.map((type) => ({
+      type,
+      mermaid: generate(data, type),
+    }));
+    const budgeted = applyArtifactBudget(generatedDiagrams, artifactProfile);
+
+    const staleMermaidFiles = fs
+      .readdirSync(outDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.mmd'))
+      .map((entry) => path.join(outDir, entry.name));
+    for (const staleFile of staleMermaidFiles) {
+      fs.rmSync(staleFile, { force: true });
+    }
+
     const manifest = {
       generatedAt: new Date().toISOString(),
       rootPath: root,
       diagramDir: path.relative(root, outDir) || '.',
+      compaction: {
+        applied: budgeted.applied,
+        profile: artifactProfile.name,
+        maxTotalBytes: artifactProfile.maxBytesTotal,
+        maxPerDiagramBytes: artifactProfile.maxBytesPerDiagram,
+        maxDiagrams: artifactProfile.maxDiagrams,
+        generatedDiagrams: budgeted.summary.generatedCount,
+        writtenDiagrams: budgeted.summary.includedCount,
+        omittedTypes: budgeted.omitted.map((entry) => entry.type),
+        truncatedTypes: budgeted.truncatedTypes,
+        bytesSaved: budgeted.summary.bytesSaved,
+        estimatedTokensSaved: estimateTokensFromBytes(budgeted.summary.bytesSaved),
+        reason: artifactProfile.name === 'full'
+          ? 'full_profile'
+          : (budgeted.applied ? 'budget_constraints' : 'within_budget'),
+      },
       diagrams: [],
     };
-    
-    for (const type of types) {
-      const mermaid = generate(data, type);
-      const file = path.join(outDir, `${type}.mmd`);
-      fs.writeFileSync(file, mermaid);
-      manifest.diagrams.push(toManifestEntry(type, file, mermaid, root));
-      if (!options.quiet) console.error(chalk.green('✅'), type, '→', file);
+
+    for (const entry of budgeted.included) {
+      const file = path.join(outDir, `${entry.type}.mmd`);
+      fs.writeFileSync(file, entry.mermaid);
+      const manifestEntry = toManifestEntry(entry.type, file, entry.mermaid, root);
+      if (entry.truncated) {
+        manifestEntry.compacted = true;
+        manifestEntry.sourceBytes = entry.originalBytes;
+        manifestEntry.bytesSaved = entry.bytesSaved;
+      }
+      manifest.diagrams.push(manifestEntry);
+      if (!options.quiet) {
+        const truncationSuffix = entry.truncated ? chalk.yellow(' [truncated]') : '';
+        console.error(chalk.green('✅'), entry.type, '→', file, truncationSuffix);
+      }
     }
 
     const manifestPath = path.join(outDir, 'manifest.json');
     fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
     if (!options.quiet) {
+      if (manifest.compaction.omittedTypes.length > 0) {
+        console.error(
+          chalk.yellow('⚠️  omitted diagrams:'),
+          manifest.compaction.omittedTypes.join(', ')
+        );
+      }
       console.error(chalk.green('✅ manifest'), '→', manifestPath);
       console.error(chalk.cyan('\n🔗 Preview all at: https://mermaid.live'));
     }
@@ -1156,7 +1208,7 @@ if (require.main === module) {
   const resolvedArgs = [];
   let commandFound = false;
   let activeCommand = null;
-  const flagsWithValue = ['-f', '--format', '-o', '--output', '-t', '--type', '-m', '--max-files', '-p', '--patterns', '-e', '--exclude', '-c', '--config', '--theme', '--duration', '--fps', '--width', '--height', '--focus', '--analyzer', '-O', '--output-dir'];
+  const flagsWithValue = ['-f', '--format', '-o', '--output', '-t', '--type', '-m', '--max-files', '-p', '--patterns', '-e', '--exclude', '-c', '--config', '--theme', '--duration', '--fps', '--width', '--height', '--focus', '--analyzer', '-O', '--output-dir', '--artifact-profile'];
 
   for (let i = 2; i < args.length; i++) {
     if (!args[i].startsWith('-')) {

--- a/test/artifact-budget.test.js
+++ b/test/artifact-budget.test.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai');
+const {
+  resolveArtifactProfile,
+  applyArtifactBudget,
+} = require('../src/artifacts/artifact-budget');
+
+function makeDiagram(type, bodyLineCount = 2) {
+  const lines = ['graph TD'];
+  for (let i = 0; i < bodyLineCount; i += 1) {
+    lines.push(`N${i}["${type}-${i}"] --> N${i + 1}["${type}-${i + 1}"]`);
+  }
+  return {
+    type,
+    mermaid: `${lines.join('\n')}\n`,
+  };
+}
+
+describe('artifact budget', () => {
+  it('keeps all diagrams unchanged in full profile', () => {
+    const diagrams = [
+      makeDiagram('flow', 4),
+      makeDiagram('architecture', 4),
+      makeDiagram('rag', 4),
+    ];
+
+    const profile = resolveArtifactProfile('full');
+    const result = applyArtifactBudget(diagrams, profile);
+
+    expect(result.applied).to.equal(false);
+    expect(result.omitted).to.have.length(0);
+    expect(result.included).to.have.length(3);
+    expect(result.included.map((entry) => entry.type)).to.deep.equal([
+      'architecture',
+      'flow',
+      'rag',
+    ]);
+    expect(result.summary.bytesSaved).to.equal(0);
+  });
+
+  it('truncates and omits diagrams in agent profile when limits are exceeded', () => {
+    const diagrams = [
+      makeDiagram('architecture', 40),
+      makeDiagram('dependency', 20),
+      makeDiagram('database', 20),
+      makeDiagram('security', 20),
+    ];
+
+    const profile = resolveArtifactProfile('agent', {
+      maxBytesPerDiagram: 350,
+      maxBytesTotal: 700,
+      maxDiagrams: 2,
+    });
+    const result = applyArtifactBudget(diagrams, profile);
+
+    expect(result.applied).to.equal(true);
+    expect(result.included).to.have.length(2);
+    expect(result.included.map((entry) => entry.type)).to.deep.equal([
+      'architecture',
+      'dependency',
+    ]);
+    expect(result.included[0].truncated).to.equal(true);
+    expect(result.included[0].mermaid).to.include('%% compacted: truncated');
+    expect(result.omitted.map((entry) => entry.type)).to.deep.equal(['database', 'security']);
+    expect(result.summary.bytesSaved).to.be.greaterThan(0);
+  });
+
+  it('rejects unknown artifact profiles', () => {
+    expect(() => resolveArtifactProfile('unknown')).to.throw('Invalid artifact profile');
+  });
+
+  it('exposes stable defaults for ultra-compact profile', () => {
+    const profile = resolveArtifactProfile('ultra-compact');
+    expect(profile.name).to.equal('ultra-compact');
+    expect(profile.maxBytesTotal).to.equal(9000);
+    expect(profile.maxBytesPerDiagram).to.equal(3000);
+    expect(profile.maxDiagrams).to.equal(3);
+  });
+});

--- a/test/context-pack.test.js
+++ b/test/context-pack.test.js
@@ -1,0 +1,101 @@
+const { expect } = require('chai');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { normalizeDiagramManifest } = require('../src/context/normalize-diagram-manifest');
+const { buildContextPack } = require('../src/context/build-context-pack');
+
+function withTempDiagrams(prefix, run) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const diagramsDir = path.join(tmpRoot, 'diagrams');
+  fs.mkdirSync(diagramsDir, { recursive: true });
+  try {
+    return run({ tmpRoot, diagramsDir });
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+describe('context pack helpers', () => {
+  it('normalizes diagrams and preserves compaction metadata in manifest', () => {
+    withTempDiagrams('diagram-context-normalize-', ({ tmpRoot, diagramsDir }) => {
+      const manifestPath = path.join(diagramsDir, 'manifest.json');
+
+      fs.writeFileSync(path.join(diagramsDir, 'architecture.mmd'), [
+        'graph TD',
+        '  subgraph A["Core"]',
+        '    N1["User Service"]',
+        '  end',
+        '',
+      ].join('\n'));
+      fs.writeFileSync(path.join(diagramsDir, 'dependency.mmd'), [
+        'graph LR',
+        '  A["External"] --> N1',
+        '',
+      ].join('\n'));
+      fs.writeFileSync(path.join(diagramsDir, 'flow.mmd'), 'flowchart TD\n  A --> B');
+      fs.writeFileSync(manifestPath, JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rootPath: '/tmp/example',
+        diagramDir: '.diagram',
+        compaction: {
+          profile: 'agent',
+          applied: true,
+        },
+        diagrams: [],
+      }));
+
+      const manifest = normalizeDiagramManifest({
+        rootDir: '/tmp/example',
+        tmpDir: tmpRoot,
+        manifestPath,
+      });
+
+      expect(manifest.compaction).to.deep.equal({
+        profile: 'agent',
+        applied: true,
+      });
+      expect(manifest.diagrams.map((entry) => entry.file)).to.deep.equal([
+        'architecture.mmd',
+        'dependency.mmd',
+        'flow.mmd',
+      ]);
+      const flowText = fs.readFileSync(path.join(diagramsDir, 'flow.mmd'), 'utf8');
+      expect(flowText.endsWith('\n')).to.equal(true);
+    });
+  });
+
+  it('builds a budgeted context pack with omitted section when constraints are tight', () => {
+    withTempDiagrams('diagram-context-build-', ({ tmpRoot, diagramsDir }) => {
+      fs.writeFileSync(path.join(diagramsDir, 'architecture.mmd'), `graph TD\n${'A --> B\n'.repeat(40)}`);
+      fs.writeFileSync(path.join(diagramsDir, 'dependency.mmd'), `graph LR\n${'X --> Y\n'.repeat(30)}`);
+      fs.writeFileSync(path.join(diagramsDir, 'database.mmd'), `flowchart TD\n${'DB --> Row\n'.repeat(20)}`);
+      fs.writeFileSync(path.join(diagramsDir, 'manifest.json'), JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rootPath: '/tmp/example',
+        diagramDir: '.diagram',
+        diagrams: [
+          { type: 'architecture', file: 'architecture.mmd', bytes: 1000, lines: 41, isPlaceholder: false },
+          { type: 'dependency', file: 'dependency.mmd', bytes: 900, lines: 31, isPlaceholder: false },
+          { type: 'database', file: 'database.mmd', bytes: 700, lines: 21, isPlaceholder: false },
+        ],
+      }));
+
+      const outputPath = path.join(tmpRoot, 'diagram-context.md');
+      const result = buildContextPack({
+        rootDir: '/tmp/example',
+        tmpDir: tmpRoot,
+        contextPath: outputPath,
+        contextMaxBytes: 1400,
+        contextMaxLinesPerDiagram: 12,
+        contextMaxEmbeddedDiagrams: 2,
+      });
+
+      const contextText = fs.readFileSync(outputPath, 'utf8');
+      expect(result.embeddedCount).to.be.at.most(2);
+      expect(contextText).to.include('## Omitted Diagrams');
+      expect(contextText).to.include('Machine-oriented context for agents');
+      expect(contextText).to.include('Note: truncated to 12 lines');
+    });
+  });
+});

--- a/test/context-pack.test.js
+++ b/test/context-pack.test.js
@@ -4,6 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { normalizeDiagramManifest } = require('../src/context/normalize-diagram-manifest');
 const { buildContextPack } = require('../src/context/build-context-pack');
+const { estimateTokensFromBytes } = require('../src/artifacts/artifact-budget');
 
 function withTempDiagrams(prefix, run) {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -97,6 +98,140 @@ describe('context pack helpers', () => {
       expect(contextText).to.include('## Omitted Diagrams');
       expect(contextText).to.include('Machine-oriented context for agents');
       expect(contextText).to.include('Note: truncated to 12 lines');
+    });
+  });
+
+  it('compacts the header/index when the context budget is tight', () => {
+    withTempDiagrams('diagram-context-header-budget-', ({ tmpRoot, diagramsDir }) => {
+      const diagrams = [];
+      for (let i = 0; i < 12; i += 1) {
+        const type = `diagram-${i}`;
+        const file = `${type}.mmd`;
+        fs.writeFileSync(path.join(diagramsDir, file), `graph TD\nA${i} --> B${i}\n`);
+        diagrams.push({
+          type,
+          file,
+          bytes: 24,
+          lines: 2,
+          isPlaceholder: false,
+        });
+      }
+
+      fs.writeFileSync(path.join(diagramsDir, 'manifest.json'), JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rootPath: '/tmp/example',
+        diagramDir: '.diagram',
+        diagrams,
+      }));
+
+      const outputPath = path.join(tmpRoot, 'diagram-context.md');
+      const result = buildContextPack({
+        rootDir: '/tmp/example',
+        tmpDir: tmpRoot,
+        contextPath: outputPath,
+        contextMaxBytes: 420,
+        contextMaxLinesPerDiagram: 10,
+        contextMaxEmbeddedDiagrams: 2,
+      });
+
+      const contextText = fs.readFileSync(outputPath, 'utf8');
+      expect(Buffer.byteLength(contextText, 'utf8')).to.be.at.most(420);
+      expect(result.headerCompacted).to.equal(true);
+      expect(result.indexRowsIncluded).to.be.at.least(0);
+    });
+  });
+
+  it('throws when context budget is too small for even a minimal header', () => {
+    withTempDiagrams('diagram-context-header-too-small-', ({ tmpRoot, diagramsDir }) => {
+      fs.writeFileSync(path.join(diagramsDir, 'architecture.mmd'), 'graph TD\nA --> B\n');
+      fs.writeFileSync(path.join(diagramsDir, 'manifest.json'), JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rootPath: '/tmp/example',
+        diagramDir: '.diagram',
+        diagrams: [
+          { type: 'architecture', file: 'architecture.mmd', bytes: 16, lines: 2, isPlaceholder: false },
+        ],
+      }));
+
+      const outputPath = path.join(tmpRoot, 'diagram-context.md');
+      expect(() => buildContextPack({
+        rootDir: '/tmp/example',
+        tmpDir: tmpRoot,
+        contextPath: outputPath,
+        contextMaxBytes: 40,
+        contextMaxLinesPerDiagram: 10,
+        contextMaxEmbeddedDiagrams: 1,
+      })).to.throw('Context byte budget (40) is too small for header.');
+    });
+  });
+
+  it('fails closed when architecture parsing produces no canonical nodes', () => {
+    withTempDiagrams('diagram-context-normalize-fail-closed-', ({ tmpRoot, diagramsDir }) => {
+      const manifestPath = path.join(diagramsDir, 'manifest.json');
+      const architecturePath = path.join(diagramsDir, 'architecture.mmd');
+      const dependencyPath = path.join(diagramsDir, 'dependency.mmd');
+      const architectureInput = 'graph TD\n  A --> B\n';
+      const dependencyInput = 'graph LR\n  X["External"] --> A\n';
+      fs.writeFileSync(architecturePath, architectureInput);
+      fs.writeFileSync(dependencyPath, dependencyInput);
+      fs.writeFileSync(manifestPath, JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rootPath: '/tmp/example',
+        diagramDir: '.diagram',
+        diagrams: [],
+      }));
+
+      expect(() => normalizeDiagramManifest({
+        rootDir: '/tmp/example',
+        tmpDir: tmpRoot,
+        manifestPath,
+      })).to.throw('Failed to normalize architecture.mmd: parsed structure was empty.');
+
+      expect(fs.readFileSync(architecturePath, 'utf8')).to.equal(architectureInput);
+      expect(fs.readFileSync(dependencyPath, 'utf8')).to.equal(dependencyInput);
+    });
+  });
+
+  it('preserves existing per-diagram metadata while recomputing derived values', () => {
+    withTempDiagrams('diagram-context-normalize-merge-', ({ tmpRoot, diagramsDir }) => {
+      const manifestPath = path.join(diagramsDir, 'manifest.json');
+      const flowPath = path.join(diagramsDir, 'flow.mmd');
+      fs.writeFileSync(flowPath, 'flowchart TD\n  A --> B\n');
+      fs.writeFileSync(manifestPath, JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        rootPath: '/tmp/example',
+        diagramDir: '.diagram',
+        compaction: {
+          profile: 'agent',
+          applied: true,
+        },
+        diagrams: [
+          {
+            type: 'flow',
+            file: 'flow.mmd',
+            compacted: true,
+            sourceBytes: 2048,
+            bytesSaved: 1900,
+            approxTokens: 1,
+            bytes: 1,
+            lines: 1,
+          },
+        ],
+      }));
+
+      const manifest = normalizeDiagramManifest({
+        rootDir: '/tmp/example',
+        tmpDir: tmpRoot,
+        manifestPath,
+      });
+      const flowEntry = manifest.diagrams.find((entry) => entry.file === 'flow.mmd');
+      expect(flowEntry).to.exist;
+      expect(flowEntry.compacted).to.equal(true);
+      expect(flowEntry.bytesSaved).to.equal(1900);
+      expect(flowEntry.sourceBytes).to.equal(2048);
+      expect(flowEntry.approxTokens).to.equal(estimateTokensFromBytes(2048));
+      expect(flowEntry.bytes).to.equal(Buffer.byteLength(fs.readFileSync(flowPath, 'utf8')));
+      expect(flowEntry.lines).to.equal(fs.readFileSync(flowPath, 'utf8').split(/\r?\n/).length);
     });
   });
 });

--- a/test/context-pack.test.js
+++ b/test/context-pack.test.js
@@ -93,6 +93,7 @@ describe('context pack helpers', () => {
 
       const contextText = fs.readFileSync(outputPath, 'utf8');
       expect(result.embeddedCount).to.be.at.most(2);
+      expect(Buffer.byteLength(contextText, 'utf8')).to.be.at.most(1400);
       expect(contextText).to.include('## Omitted Diagrams');
       expect(contextText).to.include('Machine-oriented context for agents');
       expect(contextText).to.include('Note: truncated to 12 lines');


### PR DESCRIPTION
# Pull request checklist

## Summary

- What changed (brief): Added artifact-profile-aware `generate-all` output compaction, extracted refresh context logic into reusable modules, and updated docs/CI commands to normalized CLI names.
- Why this change was needed: `.diagram` artifacts were growing too large for agent workflows, and `refresh-diagram-context.sh` needed maintainable, testable extraction points for compaction-aware context generation.
- Risk and rollback plan: Medium risk in diagram artifact shape/metadata; rollback by reverting this branch commit and re-running `scripts/refresh-diagram-context.sh`.

## Checklist

- [x] I did not push directly to `main`; this PR is from a dedicated branch.
- [x] Branch name follows policy (`codex/*` for agent-created branches).
- [x] Required local gates run: `npm test`, `npm run test:deep`, `npm run harness:check`.
- [ ] Greptile review completed and findings handled (or explicitly waived). **(Pending)**
- [ ] Greptile review was performed by an independent reviewer (not the coding agent). **(Pending)**
- [ ] Greptile confidence score is `>= 4/5` for merge eligibility. **(Pending)**
- [ ] Codex review completed and findings handled (or explicitly waived). **(Pending)**
- [x] Merge is blocked until all required checks pass.
- [x] I will delete branch/worktree after merge.

## Testing

- verification_commands: `npm_config_cache=/tmp/diagram-cli-npm-cache npm test`; `npm_config_cache=/tmp/diagram-cli-npm-cache npm run test:deep`; `npm_config_cache=/tmp/diagram-cli-npm-cache npm run harness:check`
- verification_outcomes: `npm test` pass; `npm run test:deep` pass; `npm run harness:check` fail
- blocked_steps_reason: `npm run harness:check` failed memory-gate checks (`FORJAMIE.md` stale and closeout flag not set)
- Command: `npm test` -> pass
- Command: `npm run test:deep` -> pass
- Command: `npm run harness:check` -> fail (memory-gate policy)
- Any other command(s): `bash scripts/refresh-diagram-context.sh --force --quiet` -> pass

## Review artifacts

- Greptile: pending
- Greptile confidence score: pending
- Independent reviewer evidence: pending
- Codex: this branch session evidence in local run logs
- Additional evidence (if any): context-module unit tests added in `test/context-pack.test.js` and artifact budget tests in `test/artifact-budget.test.js`

## Notes

This change improves agent-facing artifact efficiency while keeping full-profile behavior available, and it refactors context refresh logic into focused modules with regression coverage so future compaction policy changes are easier to evolve safely.
